### PR TITLE
Add free tier Super GPT fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c692ff"/>
+      <stop offset="100%" stop-color="#7037ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#0b0520"/>
+  <path d="M18 42c0-10.5 6.9-20 14-20s14 9.5 14 20c0 1.1-.1 2.2-.3 3.2h-5.7c.3-1 .5-2.1.5-3.2 0-7.4-4-13-8.5-13S24 34.6 24 42c0 1.1.2 2.2.5 3.2H18.3c-.2-1-.3-2.1-.3-3.2z" fill="url(#g)"/>
+  <circle cx="32" cy="22" r="8" fill="#c692ff" fill-opacity="0.5"/>
+</svg>

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Milana Superintelligence",
+  "short_name": "Milana AI",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#05010f",
+  "theme_color": "#a76dff",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "64x64"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,568 +1,298 @@
-
 <!DOCTYPE html>
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="description" content="Milana — портал сверхинтеллекта AKSI с готовыми мини-приложениями и интеграцией GPT.">
+    <meta name="theme-color" content="#a76dff">
+    <meta name="robots" content="index,follow">
     <title>Milana – Портал AKSI</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin:0; background-color: #f9fafb; }
-        header { background-color: #2B3A67; color: white; padding: 1rem; text-align: center; }
-        #sidebar { width: 200px; background-color: #f1f3f5; height: 100vh; position: fixed; overflow-y:auto; }
-        #sidebar ul { list-style:none; padding:0; margin:0; }
-        #sidebar li { padding: 0.5rem 1rem; border-bottom: 1px solid #dee2e6; cursor:pointer; color:#2B3A67; }
-        #sidebar li:hover { background-color:#dee2e6; }
-        #content { margin-left: 200px; padding: 1rem; }
-        .app-section { display: none; }
-        .card { background:#ffffff; padding:1rem; margin-top:1rem; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
-        button { background-color:#2B3A67; color:white; border:none; padding:0.5rem 1rem; margin-top:0.5rem; border-radius:4px; cursor:pointer; }
-        input, textarea, select { width:100%; padding:0.5rem; margin-top:0.5rem; border:1px solid #ccc; border-radius:4px; }
-        table { width:100%; border-collapse: collapse; margin-top:1rem; }
-        th, td { border:1px solid #ddd; padding:0.5rem; }
-        th { background-color:#e5e5e5; }
-    </style>
+    <link rel="icon" type="image/svg+xml" href="./assets/favicon.svg">
+    <link rel="manifest" href="./assets/site.webmanifest">
+    <link rel="stylesheet" href="./styles/main.css">
 </head>
 <body>
     <header>
-        <h1>Milana – Портал приложений AKSI</h1>
+        <div class="header-info">
+            <h1>Milana Superintelligence Hub</h1>
+            <span>Фиолетовый интерфейс для диалогов сильнее OpenAI и DeepSeek</span>
+        </div>
+        <div class="tag">Hyper AI Edition</div>
     </header>
-    <div id="sidebar">
-        <ul>
-            <li onclick="showSection('moodmirror')">moodmirror</li>
-            <li onclick="showSection('mindmirror')">mindmirror</li>
-            <li onclick="showSection('mindlink')">mindlink</li>
-            <li onclick="showSection('healthscan')">healthscan</li>
-            <li onclick="showSection('mentor')">mentor</li>
-            <li onclick="showSection('family')">family</li>
-            <li onclick="showSection('aura')">aura</li>
-            <li onclick="showSection('aksilove')">aksilove</li>
-            <li onclick="showSection('moodradio')">moodradio</li>
-            <li onclick="showSection('aksishopping')">aksishopping</li>
-            <li onclick="showSection('aistylist')">aistylist</li>
-            <li onclick="showSection('ecogaze')">ecogaze</li>
-            <li onclick="showSection('dreamjournal')">dreamjournal</li>
-            <li onclick="showSection('aksicompanion')">aksicompanion</li>
-            <li onclick="showSection('dressupar')">dressupar</li>
-            <li onclick="showSection('globalid')">globalid</li>
-            <li onclick="showSection('aksichat')">aksichat</li>
-            <li onclick="showSection('lifescan')">lifescan</li>
-            <li onclick="showSection('timecapsule')">timecapsule</li>
-            <li onclick="showSection('telehelp')">telehelp</li>
-            <li onclick="showSection('storyai')">storyai</li>
-        </ul>
-    </div>
-    <div id="content">
-        <p>Выберите приложение в списке слева, чтобы начать.</p>
-        <div id="moodmirror" class="app-section">
-<p>Определите настроение и получите отражение.</p>
+    <main id="layout" role="main">
+        <nav id="sidebar" aria-label="Приложения">
+            <div class="sidebar-header">
+                <div class="brand">
+                    <span class="brand-logo">AI</span>
+                    <div class="brand-title">
+                        <strong>Milana</strong>
+                        <span>Superintelligence</span>
+                    </div>
+                </div>
+                <button type="button" id="newChatButton">＋ Новый диалог</button>
+            </div>
+            <div class="sidebar-section">
+                <p class="sidebar-label">Приложения</p>
+                <ul>
+                    <li><button type="button" data-target="moodmirror">moodmirror</button></li>
+                    <li><button type="button" data-target="mindmirror">mindmirror</button></li>
+                    <li><button type="button" data-target="mindlink">mindlink</button></li>
+                    <li><button type="button" data-target="healthscan">healthscan</button></li>
+                    <li><button type="button" data-target="mentor">mentor</button></li>
+                    <li><button type="button" data-target="family">family</button></li>
+                    <li><button type="button" data-target="aura">aura</button></li>
+                    <li><button type="button" data-target="aksilove">aksilove</button></li>
+                    <li><button type="button" data-target="moodradio">moodradio</button></li>
+                    <li><button type="button" data-target="aksishopping">aksishopping</button></li>
+                    <li><button type="button" data-target="aistylist">aistylist</button></li>
+                    <li><button type="button" data-target="ecogaze">ecogaze</button></li>
+                    <li><button type="button" data-target="dreamjournal">dreamjournal</button></li>
+                    <li><button type="button" data-target="aksicompanion">aksicompanion</button></li>
+                    <li><button type="button" data-target="dressupar">dressupar</button></li>
+                    <li><button type="button" data-target="globalid">globalid</button></li>
+                    <li><button type="button" data-target="aksichat">aksichat</button></li>
+                    <li><button type="button" data-target="lifescan">lifescan</button></li>
+                    <li><button type="button" data-target="timecapsule">timecapsule</button></li>
+                    <li><button type="button" data-target="telehelp">telehelp</button></li>
+                    <li><button type="button" data-target="storyai">storyai</button></li>
+                </ul>
+            </div>
+            <div class="sidebar-footer">
+                Milana Hyper AI удерживает ваш ключ только в браузере и открывает сверхбыстрые ответы. Переключайтесь между модулями без перезапуска.
+            </div>
+        </nav>
+        <div id="content">
+            <div class="content-inner">
+                <div class="hero-card">
+                    <div>
+                        <h2>Milana Hyperintelligence</h2>
+                        <p>Испытайте фиолетовый интерфейс, вдохновлённый ChatGPT, но усиленный движком AKSI. Бесплатный режим Super GPTb соединяет память, интернет-оркестратор и мгновенные статусы — без ожидания ключа.</p>
+                        <div class="hero-actions">
+                            <button type="button" id="launchAksichat">Открыть суперчат</button>
+                            <span class="tag">Realtime Insight</span>
+                            <span class="tag">Orchestrated Prompts</span>
+                            <span class="tag free-tier">Free Tier Ready</span>
+                        </div>
+                    </div>
+                </div>
 
-<select id="moodSelect">
-  <option value="happy">Счастливый</option>
-  <option value="sad">Грустный</option>
-  <option value="angry">Злой</option>
-  <option value="calm">Спокойный</option>
-</select>
-<button onclick="showMood()">Показать</button>
-<div id="moodDisplay" style="height:100px; display:flex; align-items:center; justify-content:center; border-radius:8px; margin-top:1rem;"></div>
-<script>
-function showMood() {
-    const mood = document.getElementById('moodSelect').value;
-    const display = document.getElementById('moodDisplay');
-    let color = '';
-    let text = '';
-    switch(mood) {
-        case 'happy': color = '#ffe066'; text = 'Вы счастливы!'; break;
-        case 'sad': color = '#74c0fc'; text = 'Вы грустите.'; break;
-        case 'angry': color = '#fa5252'; text = 'Вы злитесь.'; break;
-        case 'calm': color = '#b2f2bb'; text = 'Вы спокойны.'; break;
-    }
-    display.style.backgroundColor = color;
-    display.innerText = text;
-}
-</script>
+                <div id="gptIntegration" class="card">
+                <h2>Интеграция с GPT</h2>
+                <p>Milana Super GPTb уже готова отвечать в бесплатном режиме. Введите ключ OpenAI API, чтобы подключить облачные модели и увеличить мощность.</p>
+                <div class="free-tier-callout">
+                    <strong>Бесплатный режим:</strong> суперчат работает на памяти и интернет-данных даже без ключа. Ключ нужен только для прямого доступа к API OpenAI.
+                </div>
+                <div class="inline-input-group">
+                    <input type="password" id="gptApiKey" placeholder="sk-..." autocomplete="off">
+                    <button type="button" id="gptSaveKey">Сохранить ключ</button>
+                    <button type="button" id="gptTestKey" class="secondary">Проверить</button>
+                    <button type="button" id="gptClearKey" class="secondary">Удалить</button>
+                </div>
+                <p id="gptKeyStatus" class="note"></p>
+                <p class="note">Ключ хранится локально в вашем браузере. Для повышенной безопасности рекомендуется использовать прокси-сервер.</p>
+            </div>
+
+            <div id="gptCognition" class="card cognition-card">
+                <h2>Память и интернет-оркестратор GPTb</h2>
+                <p id="knowledgeStatus" class="note"></p>
+                <div class="cognition-grid">
+                    <section aria-labelledby="memoryStatus">
+                        <h3>Долгосрочная память</h3>
+                        <p id="memoryStatus" class="note"></p>
+                        <button type="button" id="memoryClearButton" class="secondary">Очистить память</button>
+                    </section>
+                    <section>
+                        <h3>Источники внешних данных</h3>
+                        <ul id="knowledgeSourcesList" class="knowledge-sources"></ul>
+                        <div class="knowledge-actions">
+                            <button type="button" id="knowledgeRefreshButton">Обновить данные</button>
+                            <span class="note small-note">Данные хранятся только локально и обновляются по запросу.</span>
+                        </div>
+                        <pre id="knowledgePreview" class="knowledge-preview" aria-live="polite"></pre>
+                    </section>
+                </div>
+            </div>
+
+            <div id="moodmirror" class="app-section">
+                <p>Определите настроение и получите отражение.</p>
+                <select id="moodMirrorSelect">
+                    <option value="happy">Счастливый</option>
+                    <option value="sad">Грустный</option>
+                    <option value="angry">Злой</option>
+                    <option value="calm">Спокойный</option>
+                </select>
+                <button type="button" id="moodMirrorButton">Показать</button>
+                <div id="moodMirrorDisplay" class="mood-display"></div>
+            </div>
+
+            <div id="mindmirror" class="app-section">
+                <p>Записывайте мысли и получайте совет.</p>
+                <textarea id="mindMirrorEntry" placeholder="Опишите свои мысли..."></textarea>
+                <button type="button" id="mindMirrorSave">Сохранить</button>
+                <div id="mindMirrorEntries"></div>
+                <p id="mindMirrorReflection"></p>
+            </div>
+
+            <div id="mindlink" class="app-section">
+                <p>Симуляция интерфейса мозг–компьютер.</p>
+                <progress id="mindLinkProgress" max="100" value="50"></progress>
+                <p id="mindLinkStatus">Средняя активность</p>
+                <button type="button" id="mindLinkButton">Обновить</button>
+            </div>
+
+            <div id="healthscan" class="app-section">
+                <p>Простой анализ здоровья на основе пульса и давления.</p>
+                <input type="number" id="healthPulse" placeholder="Пульс (уд/мин)">
+                <input type="number" id="healthSystolic" placeholder="Систолическое давление">
+                <button type="button" id="healthScanButton">Анализировать</button>
+                <div id="healthResult"></div>
+            </div>
+
+            <div id="mentor" class="app-section">
+                <p>Получите мотивационный совет.</p>
+                <button type="button" id="mentorAdviceButton">Получить совет</button>
+                <p id="mentorAdvice"></p>
+            </div>
+
+            <div id="family" class="app-section">
+                <p>Организуйте семейные события и задачи.</p>
+                <input id="familyEventName" placeholder="Название события">
+                <input type="date" id="familyEventDate">
+                <button type="button" id="familyAddButton">Добавить</button>
+                <table id="familyEventsTable"></table>
+            </div>
+
+            <div id="aura" class="app-section">
+                <p>Определите вашу «ауру» и цвет настроения.</p>
+                <select id="auraMoodSelect">
+                    <option value="happy">Счастливый</option>
+                    <option value="sad">Грустный</option>
+                    <option value="angry">Злой</option>
+                    <option value="calm">Спокойный</option>
+                </select>
+                <button type="button" id="auraMoodButton">Показать</button>
+                <div id="auraMoodDisplay" class="mood-display"></div>
+            </div>
+
+            <div id="aksilove" class="app-section">
+                <p>Найдите свою пару в случайном подборе.</p>
+                <input id="loveYourName" placeholder="Ваше имя">
+                <input id="lovePreference" placeholder="Кого вы ищете (характеристика)">
+                <button type="button" id="loveMatchButton">Найти пару</button>
+                <p id="loveMatchResult"></p>
+            </div>
+
+            <div id="moodradio" class="app-section">
+                <p>Плейлисты под ваше настроение.</p>
+                <select id="moodRadioSelect">
+                    <option value="happy">Счастливый</option>
+                    <option value="sad">Грустный</option>
+                    <option value="angry">Злой</option>
+                    <option value="calm">Спокойный</option>
+                </select>
+                <button type="button" id="moodRadioButton">Показать плейлист</button>
+                <ul id="moodRadioList"></ul>
+            </div>
+
+            <div id="aksishopping" class="app-section">
+                <p>Простая корзина для покупки товаров.</p>
+                <div id="cartCount"></div>
+                <div id="productList"></div>
+            </div>
+
+            <div id="aistylist" class="app-section">
+                <p>Персональный стилист: получите рекомендации по стилю.</p>
+                <input id="stylistPreference" placeholder="Введите предпочтение (цвет, стиль...)">
+                <button type="button" id="stylistButton">Получить рекомендацию</button>
+                <p id="stylistAdvice"></p>
+            </div>
+
+            <div id="ecogaze" class="app-section">
+                <p>Оцените экологические показатели вокруг вас.</p>
+                <input type="number" id="ecoLight" placeholder="Освещённость (люкс)">
+                <input type="number" id="ecoNoise" placeholder="Шум (дБ)">
+                <input type="number" id="ecoCO2" placeholder="CO₂ (ppm)">
+                <button type="button" id="ecoAnalyzeButton">Анализировать</button>
+                <div id="ecoResult"></div>
+            </div>
+
+            <div id="dreamjournal" class="app-section">
+                <p>Ведите дневник снов прямо в браузере.</p>
+                <textarea id="dreamEntry" placeholder="Опишите ваш сон..."></textarea>
+                <button type="button" id="dreamSaveButton">Сохранить запись</button>
+                <div id="dreamEntries"></div>
+            </div>
+
+            <div id="aksicompanion" class="app-section">
+                <p>Виртуальный компаньон, которого можно кормить и слушать.</p>
+                <p id="companionMessage"></p>
+                <p id="companionStatus">Уровень радости: 50%</p>
+                <button type="button" id="companionTalkButton">Сказать что-то</button>
+                <button type="button" id="companionFeedButton">Накормить</button>
+            </div>
+
+            <div id="dressupar" class="app-section">
+                <p>Примерка одежды в режиме дополненной реальности (демо-версия для веб).</p>
+                <select id="dressUpSelect">
+                    <option value="">Выберите одежду</option>
+                    <option value="Платье">Платье</option>
+                    <option value="Костюм">Костюм</option>
+                    <option value="Спортивный комплект">Спортивный комплект</option>
+                </select>
+                <button type="button" id="dressUpButton">Примерить</button>
+                <p id="dressUpResult"></p>
+            </div>
+
+            <div id="globalid" class="app-section">
+                <p>Создайте цифровое удостоверение личности.</p>
+                <input id="globalIdName" placeholder="ФИО">
+                <input id="globalIdNumber" placeholder="Номер ID">
+                <button type="button" id="globalIdButton">Сгенерировать удостоверение</button>
+                <div id="globalIdCard" class="card"></div>
+            </div>
+
+            <div id="aksichat" class="app-section">
+                <p>Подключите GPT, чтобы получать живые ответы от виртуального ассистента.</p>
+                <div id="chatBox" class="card"></div>
+                <input id="chatInput" placeholder="Введите сообщение">
+                <button type="button" id="chatSendButton">Отправить</button>
+                <p id="chatStatus" class="note"></p>
+            </div>
+
+            <div id="lifescan" class="app-section">
+                <p>Расчёт индекса массы тела (ИМТ).</p>
+                <input type="number" id="lifeWeight" placeholder="Вес (кг)">
+                <input type="number" id="lifeHeight" placeholder="Рост (см)">
+                <button type="button" id="lifeCalcButton">Рассчитать ИМТ</button>
+                <div id="lifeBmiResult"></div>
+            </div>
+
+            <div id="timecapsule" class="app-section">
+                <p>Создайте капсулу времени — сообщение, которое откроется позже.</p>
+                <textarea id="capsuleMessage" placeholder="Сообщение в будущее"></textarea>
+                <input type="datetime-local" id="capsuleDate">
+                <button type="button" id="capsuleSaveButton">Сохранить</button>
+                <button type="button" id="capsuleOpenButton">Открыть доступные сообщения</button>
+                <div id="capsuleList"></div>
+            </div>
+
+            <div id="telehelp" class="app-section">
+                <p>Служба SOS для экстренных случаев.</p>
+                <button type="button" id="telehelpButton">Отправить SOS</button>
+                <p id="telehelpResult"></p>
+            </div>
+
+            <div id="storyai" class="app-section">
+                <p>Создайте короткий рассказ из вашей идеи с помощью GPT.</p>
+                <input id="storyPrompt" placeholder="Введите тему или героя...">
+                <button type="button" id="storyButton">Сгенерировать историю</button>
+                <div id="storyOutput" class="card"></div>
+                <p id="storyStatus" class="note"></p>
+            </div>
+            </div>
         </div>
-        <div id="mindmirror" class="app-section">
-<p>Записывайте мысли и получайте совет.</p>
+    </main>
 
-<textarea id="mindEntry" placeholder="Опишите свои мысли..."></textarea>
-<button onclick="saveMindEntry()">Сохранить</button>
-<div id="mindEntries"></div>
-<p id="reflection"></p>
-<script>
-const reflections = ['Попробуйте выразить благодарность за что-то.', 'Сделайте глубокий вдох и расслабьтесь.', 'Запишите положительный момент из дня.', 'Уделите время отдыху и восстановлению.'];
-function loadMindEntries() {
-    const entries = JSON.parse(localStorage.getItem('mindEntries') || '[]');
-    const container = document.getElementById('mindEntries');
-    container.innerHTML = '';
-    entries.forEach((entry, idx) => {
-        container.innerHTML += '<div class="card"><strong>Запись ' + (idx+1) + '</strong><p>' + entry + '</p></div>';
-    });
-}
-function saveMindEntry() {
-    const text = document.getElementById('mindEntry').value.trim();
-    if(!text) return;
-    const entries = JSON.parse(localStorage.getItem('mindEntries') || '[]');
-    entries.push(text);
-    localStorage.setItem('mindEntries', JSON.stringify(entries));
-    document.getElementById('mindEntry').value = '';
-    loadMindEntries();
-    const refl = reflections[Math.floor(Math.random()*reflections.length)];
-    document.getElementById('reflection').innerText = 'Совет: ' + refl;
-}
-window.onload = loadMindEntries;
-</script>
-        </div>
-        <div id="mindlink" class="app-section">
-<p>Симуляция интерфейса мозг–компьютер.</p>
-
-<progress id="brainProgress" max="100" value="50"></progress>
-<p id="brainStatus">Средняя активность</p>
-<button onclick="updateBrain()">Обновить</button>
-<script>
-function updateBrain() {
-    const progress = document.getElementById('brainProgress');
-    const status = document.getElementById('brainStatus');
-    const val = Math.floor(Math.random()*101);
-    progress.value = val;
-    if(val < 33) status.innerText = 'Низкая активность';
-    else if(val < 66) status.innerText = 'Средняя активность';
-    else status.innerText = 'Высокая активность';
-}
-</script>
-        </div>
-        <div id="healthscan" class="app-section">
-<p>Простой анализ здоровья на основе пульса и давления.</p>
-
-<input type="number" id="heartRate" placeholder="Пульс (уд/мин)">
-<input type="number" id="systolic" placeholder="Систолическое давление">
-<button onclick="analyzeHealth()">Анализировать</button>
-<div id="healthResult"></div>
-<script>
-function analyzeHealth() {
-    const heart = parseInt(document.getElementById('heartRate').value);
-    const sys = parseInt(document.getElementById('systolic').value);
-    let msg = '';
-    if(heart > 100) msg += 'Повышенный пульс. ';
-    else if(heart < 60) msg += 'Низкий пульс. ';
-    else msg += 'Пульс в норме. ';
-    if(sys > 140) msg += 'Высокое давление. ';
-    else if(sys < 90) msg += 'Низкое давление. ';
-    else msg += 'Давление в норме.';
-    document.getElementById('healthResult').innerText = msg;
-}
-</script>
-        </div>
-        <div id="mentor" class="app-section">
-<p>Получите мотивационный совет.</p>
-
-<button onclick="getAdvice()">Получить совет</button>
-<p id="advice"></p>
-<script>
-const advices = [
-    'Верить в себя — первый шаг к успеху.',
-    'Каждый день учитесь чему-то новому.',
-    'Планируйте и ставьте маленькие цели.',
-    'Не бойтесь ошибок — они учат.'
-];
-function getAdvice() {
-    const advice = advices[Math.floor(Math.random()*advices.length)];
-    document.getElementById('advice').innerText = advice;
-}
-</script>
-        </div>
-        <div id="family" class="app-section">
-<p>Организуйте семейные события и задачи.</p>
-
-<input id="eventName" placeholder="Название события">
-<input type="date" id="eventDate">
-<button onclick="addEvent()">Добавить</button>
-<table id="eventsTable"></table>
-<script>
-function loadEvents() {
-    const events = JSON.parse(localStorage.getItem('familyEvents') || '[]');
-    const table = document.getElementById('eventsTable');
-    let html = '<tr><th>Событие</th><th>Дата</th></tr>';
-    events.forEach(ev => {
-        html += '<tr><td>' + ev.name + '</td><td>' + ev.date + '</td></tr>';
-    });
-    table.innerHTML = html;
-}
-function addEvent() {
-    const name = document.getElementById('eventName').value.trim();
-    const date = document.getElementById('eventDate').value;
-    if(!name || !date) return;
-    const events = JSON.parse(localStorage.getItem('familyEvents') || '[]');
-    events.push({name:name, date:date});
-    localStorage.setItem('familyEvents', JSON.stringify(events));
-    document.getElementById('eventName').value = '';
-    document.getElementById('eventDate').value = '';
-    loadEvents();
-}
-window.onload = loadEvents;
-</script>
-        </div>
-        <div id="aura" class="app-section">
-<p>Определите вашу 'ауру' и цвет настроения.</p>
-
-<select id="moodSelect">
-  <option value="happy">Счастливый</option>
-  <option value="sad">Грустный</option>
-  <option value="angry">Злой</option>
-  <option value="calm">Спокойный</option>
-</select>
-<button onclick="showMood()">Показать</button>
-<div id="moodDisplay" style="height:100px; display:flex; align-items:center; justify-content:center; border-radius:8px; margin-top:1rem;"></div>
-<script>
-function showMood() {
-    const mood = document.getElementById('moodSelect').value;
-    const display = document.getElementById('moodDisplay');
-    let color = '';
-    let text = '';
-    switch(mood) {
-        case 'happy': color = '#ffe066'; text = 'Вы счастливы!'; break;
-        case 'sad': color = '#74c0fc'; text = 'Вы грустите.'; break;
-        case 'angry': color = '#fa5252'; text = 'Вы злитесь.'; break;
-        case 'calm': color = '#b2f2bb'; text = 'Вы спокойны.'; break;
-    }
-    display.style.backgroundColor = color;
-    display.innerText = text;
-}
-</script>
-        </div>
-        <div id="aksilove" class="app-section">
-<p>Найдите свою пару в случайном подборе.</p>
-
-<input id="yourName" placeholder="Ваше имя">
-<input id="preference" placeholder="Кого вы ищете (характеристика)">
-<button onclick="findMatch()">Найти пару</button>
-<p id="matchResult"></p>
-<script>
-const matches = ['Алексей','Ольга','Сергей','Мария','Иван','Екатерина'];
-function findMatch() {
-    const name = document.getElementById('yourName').value.trim();
-    const pref = document.getElementById('preference').value.trim();
-    const match = matches[Math.floor(Math.random()*matches.length)];
-    document.getElementById('matchResult').innerText = (name ? name + ', ' : '') + 'ваша совместимость на сегодня: ' + match + (pref ? (' (учитывая предпочтение: ' + pref + ')') : '');
-}
-</script>
-        </div>
-        <div id="moodradio" class="app-section">
-<p>Плейлисты под ваше настроение.</p>
-
-<select id="radioMood">
-  <option value="happy">Счастливый</option>
-  <option value="sad">Грустный</option>
-  <option value="angry">Злой</option>
-  <option value="calm">Спокойный</option>
-</select>
-<button onclick="playList()">Показать плейлист</button>
-<ul id="songList"></ul>
-<script>
-const moodSongs = {
-    happy: ['Happy Song 1', 'Joyful Tune 2', 'Sunny Day'],
-    sad: ['Melancholic Melody', 'Slow Ballad', 'Rainy Thoughts'],
-    angry: ['Rock Anthem', 'Metal Fury', 'Energetic Beat'],
-    calm: ['Peaceful Piano', 'Relaxing Waves', 'Soft Guitar']
-};
-function playList() {
-    const mood = document.getElementById('radioMood').value;
-    const list = document.getElementById('songList');
-    list.innerHTML = '';
-    moodSongs[mood].forEach(song => {
-        const li = document.createElement('li');
-        li.textContent = song;
-        list.appendChild(li);
-    });
-}
-</script>
-        </div>
-        <div id="aksishopping" class="app-section">
-<p>Простая корзина для покупки товаров.</p>
-
-<div id="cartCount"></div>
-<div id="productList"></div>
-<script>
-const products = [
-  {name:'Смартфон', price:500},
-  {name:'Наушники', price:50},
-  {name:'Ноутбук', price:800},
-  {name:'Фитнес‑браслет', price:100}
-];
-let cart = JSON.parse(localStorage.getItem('shopCart') || '[]');
-function updateCart() {
-    document.getElementById('cartCount').innerText = 'В корзине: ' + cart.length;
-}
-function addToCart(index) {
-    cart.push(products[index]);
-    localStorage.setItem('shopCart', JSON.stringify(cart));
-    updateCart();
-}
-function renderProducts() {
-    const list = document.getElementById('productList');
-    list.innerHTML = '';
-    products.forEach((p, i) => {
-        list.innerHTML += '<div class="card"><p><strong>' + p.name + '</strong> — ' + p.price + '₽</p><button onclick="addToCart(' + i + ')">Добавить в корзину</button></div>';
-    });
-}
-window.onload = function() {
-    updateCart();
-    renderProducts();
-};
-</script>
-        </div>
-        <div id="aistylist" class="app-section">
-<p>Персональный стилист: получите рекомендации по стилю.</p>
-
-<input id="stylePref" placeholder="Введите предпочтение (цвет, стиль...)">
-<button onclick="getStyleAdvice()">Получить рекомендацию</button>
-<p id="styleAdvice"></p>
-<script>
-const outfits = [
-    'Белая рубашка с джинсами — классика, которая подходит всем.',
-    'Пастельные тона и лёгкие ткани — отличный выбор для весны.',
-    'Спортивный костюм сочетается с кроссовками для активного дня.',
-    'Деловой костюм подчеркнёт вашу уверенность.'
-];
-function getStyleAdvice() {
-    const pref = document.getElementById('stylePref').value.trim();
-    const advice = outfits[Math.floor(Math.random()*outfits.length)];
-    document.getElementById('styleAdvice').innerText = advice + (pref ? (' Учтите ваш выбор: ' + pref + '.') : '');
-}
-</script>
-        </div>
-        <div id="ecogaze" class="app-section">
-<p>Оцените экологические показатели вокруг вас.</p>
-
-<input type="number" id="light" placeholder="Освещённость (люкс)">
-<input type="number" id="noise" placeholder="Шум (дБ)">
-<input type="number" id="co2" placeholder="CO₂ (ppm)">
-<button onclick="analyzeEco()">Анализировать</button>
-<div id="ecoResult"></div>
-<script>
-function analyzeEco() {
-    const light = parseFloat(document.getElementById('light').value);
-    const noise = parseFloat(document.getElementById('noise').value);
-    const co2 = parseFloat(document.getElementById('co2').value);
-    let result = '';
-    result += (light >= 300 && light <= 500) ? 'Хорошая освещённость. ' : 'Плохая освещённость. ';
-    result += (noise <= 50) ? 'Шум в норме. ' : 'Шум высокий. ';
-    result += (co2 <= 1000) ? 'CO₂ в норме.' : 'Повышенный CO₂.';
-    document.getElementById('ecoResult').innerText = result;
-}
-</script>
-        </div>
-        <div id="dreamjournal" class="app-section">
-<p>Ведите дневник снов прямо в браузере.</p>
-
-<textarea id="journalEntry" placeholder="Опишите ваш сон..."></textarea>
-<button onclick="saveEntry()">Сохранить запись</button>
-<div id="entries"></div>
-<script>
-function loadEntries() {
-    const entries = JSON.parse(localStorage.getItem('dreamEntries') || '[]');
-    const container = document.getElementById('entries');
-    container.innerHTML = '';
-    entries.forEach((entry, idx) => {
-        container.innerHTML += '<div class="card"><strong>Запись ' + (idx + 1) + '</strong><p>' + entry + '</p></div>';
-    });
-}
-function saveEntry() {
-    const text = document.getElementById('journalEntry').value.trim();
-    if(!text) return;
-    const entries = JSON.parse(localStorage.getItem('dreamEntries') || '[]');
-    entries.push(text);
-    localStorage.setItem('dreamEntries', JSON.stringify(entries));
-    document.getElementById('journalEntry').value = '';
-    loadEntries();
-}
-window.onload = loadEntries;
-</script>
-        </div>
-        <div id="aksicompanion" class="app-section">
-<p>Виртуальный компаньон, которого можно кормить и слушать.</p>
-
-<p id="companionMessage"></p>
-<p id="companionStatus">Уровень радости: 50%</p>
-<button onclick="companionTalk()">Сказать что‑то</button>
-<button onclick="companionFeed()">Накормить</button>
-<script>
-let happiness = 50;
-const phrases = ['Приятно с вами общаться!', 'Надеюсь, у вас хороший день!', 'Я всегда рядом.', 'Расскажите мне что-то новое.'];
-function updateCompanion() {
-    document.getElementById('companionStatus').innerText = 'Уровень радости: ' + happiness + '%';
-}
-function companionTalk() {
-    const phrase = phrases[Math.floor(Math.random()*phrases.length)];
-    document.getElementById('companionMessage').innerText = phrase;
-    happiness = Math.min(100, happiness + 5);
-    updateCompanion();
-}
-function companionFeed() {
-    document.getElementById('companionMessage').innerText = 'Спасибо за еду! :)';
-    happiness = Math.min(100, happiness + 10);
-    updateCompanion();
-}
-window.onload = updateCompanion;
-</script>
-        </div>
-        <div id="dressupar" class="app-section">
-<p>Примерка одежды в режиме дополненной реальности (демо-версия для веб).</p>
-
-<select id="clothingSelect">
-  <option value="">Выберите одежду</option>
-  <option value="Платье">Платье</option>
-  <option value="Костюм">Костюм</option>
-  <option value="Спортивный комплект">Спортивный комплект</option>
-</select>
-<button onclick="applyClothing()">Примерить</button>
-<p id="clothingResult"></p>
-<script>
-function applyClothing() {
-    const item = document.getElementById('clothingSelect').value;
-    document.getElementById('clothingResult').innerText = item ? ('Вы выбрали: ' + item) : '';
-}
-</script>
-        </div>
-        <div id="globalid" class="app-section">
-<p>Создайте цифровое удостоверение личности.</p>
-
-<input id="fullName" placeholder="ФИО">
-<input id="idNumber" placeholder="Номер ID">
-<button onclick="generateID()">Сгенерировать удостоверение</button>
-<div id="idCard" class="card"></div>
-<script>
-function generateID() {
-    const name = document.getElementById('fullName').value.trim();
-    const number = document.getElementById('idNumber').value.trim();
-    if(!name || !number) return;
-    const card = document.getElementById('idCard');
-    card.innerHTML = '<p><strong>Имя:</strong> ' + name + '</p><p><strong>ID:</strong> ' + number + '</p>';
-}
-</script>
-        </div>
-        <div id="aksichat" class="app-section">
-<p>Простой чат-бот с ответами.</p>
-
-<div id="chatBox" class="card" style="height:300px; overflow-y:auto;"></div>
-<input id="chatInput" placeholder="Введите сообщение"/>
-<button onclick="sendChat()">Отправить</button>
-<script>
-const responses = ["Хорошо!", "Расскажите больше!", "Интересно.", "Я не уверен, что понимаю.", "Продолжайте..."];
-function sendChat() {
-    const input = document.getElementById('chatInput');
-    const box = document.getElementById('chatBox');
-    const text = input.value.trim();
-    if (!text) return;
-    box.innerHTML += '<div><strong>Вы:</strong> ' + text + '</div>';
-    const resp = responses[Math.floor(Math.random() * responses.length)];
-    box.innerHTML += '<div><strong>Милана:</strong> ' + resp + '</div>';
-    input.value = '';
-    box.scrollTop = box.scrollHeight;
-}
-</script>
-        </div>
-        <div id="lifescan" class="app-section">
-<p>Расчёт индекса массы тела (ИМТ).</p>
-
-<input type="number" id="weight" placeholder="Вес (кг)">
-<input type="number" id="height" placeholder="Рост (см)">
-<button onclick="calcBMI()">Рассчитать ИМТ</button>
-<div id="bmiResult"></div>
-<script>
-function calcBMI() {
-    const weight = parseFloat(document.getElementById('weight').value);
-    const height = parseFloat(document.getElementById('height').value) / 100;
-    if(!weight || !height) return;
-    const bmi = weight / (height * height);
-    let category = '';
-    if(bmi < 18.5) category = 'Недостаток веса';
-    else if(bmi < 25) category = 'Норма';
-    else if(bmi < 30) category = 'Избыточный вес';
-    else category = 'Ожирение';
-    document.getElementById('bmiResult').innerText = 'ИМТ: ' + bmi.toFixed(1) + ' — ' + category;
-}
-</script>
-        </div>
-        <div id="timecapsule" class="app-section">
-<p>Создайте капсулу времени — сообщение, которое откроется позже.</p>
-
-<textarea id="capsuleMessage" placeholder="Сообщение в будущее"></textarea>
-<input type="datetime-local" id="capsuleDate">
-<button onclick="saveCapsule()">Сохранить</button>
-<button onclick="openCapsules()">Открыть доступные сообщения</button>
-<div id="capsuleList"></div>
-<script>
-function loadCapsules() {
-    return JSON.parse(localStorage.getItem('timeCapsules') || '[]');
-}
-function saveCapsule() {
-    const msg = document.getElementById('capsuleMessage').value.trim();
-    const date = document.getElementById('capsuleDate').value;
-    if(!msg || !date) return;
-    const capsules = loadCapsules();
-    capsules.push({msg: msg, date: date});
-    localStorage.setItem('timeCapsules', JSON.stringify(capsules));
-    document.getElementById('capsuleMessage').value = '';
-    document.getElementById('capsuleDate').value = '';
-}
-function openCapsules() {
-    const now = new Date();
-    const capsules = loadCapsules();
-    const container = document.getElementById('capsuleList');
-    container.innerHTML = '';
-    capsules.forEach(capsule => {
-        const openDate = new Date(capsule.date);
-        if(openDate <= now) {
-            container.innerHTML += '<div class="card"><p>' + capsule.msg + '</p><small>Дата создания: ' + capsule.date + '</small></div>';
-        }
-    });
-}
-</script>
-        </div>
-        <div id="telehelp" class="app-section">
-<p>Служба SOS для экстренных случаев.</p>
-
-<button onclick="sendSOS()">Отправить SOS</button>
-<p id="sosResult"></p>
-<script>
-function sendSOS() {
-    document.getElementById('sosResult').innerText = 'Запрос SOS отправлен! Дождитесь помощи.';
-}
-</script>
-        </div>
-        <div id="storyai" class="app-section">
-<p>Создайте короткий рассказ из вашей идеи.</p>
-
-<input id="storyPrompt" placeholder="Введите тему или героя...">
-<button onclick="generateStory()">Сгенерировать историю</button>
-<div id="storyOutput" class="card"></div>
-<script>
-const storyTemplates = [
-    "Однажды {prompt}, и это привело к удивительному приключению, полному неожиданных поворотов.",
-    "История о {prompt} началась в туманное утро, когда мир перевернулся с ног на голову.",
-    "{prompt} — герой, который доказал, что даже самые смелые мечты могут стать реальностью.",
-    "В далёком королевстве жил {prompt}, и однажды он нашёл секрет, изменивший всё."
-];
-function generateStory() {
-    const prompt = document.getElementById('storyPrompt').value.trim();
-    if(!prompt) return;
-    const template = storyTemplates[Math.floor(Math.random()*storyTemplates.length)];
-    const story = template.replace('{prompt}', prompt);
-    document.getElementById('storyOutput').innerText = story;
-}
-</script>
-        </div>
-    </div>
-
-<script>
-    function showSection(id) {
-        const sections = document.querySelectorAll('.app-section');
-        sections.forEach(s => s.style.display = 'none');
-        const target = document.getElementById(id);
-        if(target) {
-            target.style.display = 'block';
-        }
-    }
-</script>
-
+    <script type="module" src="./scripts/main.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2572 @@
+{
+  "name": "milana_site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "milana_site",
+      "version": "1.0.0",
+      "devDependencies": {
+        "jsdom": "^24.0.0",
+        "vitest": "^1.6.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "milana_site",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/scripts/free-tier.js
+++ b/scripts/free-tier.js
@@ -1,0 +1,170 @@
+const normaliseTopic = (text) => {
+    if (!text) return '';
+    return String(text).toLowerCase().replace(/\s+/g, ' ').trim();
+};
+
+const toArray = (value) => Array.isArray(value) ? value : [];
+
+const limitText = (text, maxLength = 900) => {
+    if (!text) return '';
+    const content = String(text);
+    return content.length > maxLength ? `${content.slice(0, maxLength)}…` : content;
+};
+
+export function createFreeTierEngine({
+    knowledgeHub,
+    memoryVault,
+    clock = () => new Date(),
+    cacheTtl = 60_000
+} = {}) {
+    if (!knowledgeHub || typeof knowledgeHub.gather !== 'function') {
+        throw new Error('Для бесплатного движка требуется knowledgeHub с методом gather.');
+    }
+    if (!memoryVault || typeof memoryVault.recall !== 'function') {
+        throw new Error('Для бесплатного движка требуется memoryVault с методом recall.');
+    }
+
+    let aggregation = {
+        topic: '',
+        originalTopic: '',
+        combinedText: '',
+        entries: [],
+        errors: [],
+        timestamp: 0
+    };
+
+    const recordAggregation = ({ topic, combinedText = '', entries = [], errors = [] } = {}) => {
+        aggregation = {
+            topic: normaliseTopic(topic),
+            originalTopic: topic || '',
+            combinedText: combinedText || '',
+            entries: toArray(entries),
+            errors: toArray(errors),
+            timestamp: Date.now()
+        };
+    };
+
+    const ensureAggregation = async (topicText) => {
+        const normalised = normaliseTopic(topicText);
+        const isCached = normalised
+            && aggregation.topic === normalised
+            && Date.now() - aggregation.timestamp < cacheTtl;
+
+        if (isCached) {
+            return aggregation;
+        }
+
+        if (!normalised) {
+            aggregation = {
+                topic: '',
+                originalTopic: '',
+                combinedText: '',
+                entries: [],
+                errors: ['Пока нет запроса для бесплатного движка.'],
+                timestamp: Date.now()
+            };
+            return aggregation;
+        }
+
+        try {
+            const result = await knowledgeHub.gather(topicText, { limit: 4 });
+            aggregation = {
+                topic: normalised,
+                originalTopic: topicText,
+                combinedText: result?.combinedText || '',
+                entries: toArray(result?.entries),
+                errors: toArray(result?.errors),
+                timestamp: Date.now()
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            aggregation = {
+                topic: normalised,
+                originalTopic: topicText,
+                combinedText: '',
+                entries: [],
+                errors: [message],
+                timestamp: Date.now()
+            };
+        }
+
+        return aggregation;
+    };
+
+    const buildKnowledgeBlock = (data) => {
+        if (!data) {
+            return '🌐 Ожидаю сигнал от интернет-источников.';
+        }
+        if (data.combinedText) {
+            return `📚 Интернет-досье:\n${limitText(data.combinedText, 900)}`;
+        }
+        if (data.errors.length) {
+            return `🌐 Источники временно недоступны: ${data.errors[0]}`;
+        }
+        return '🌐 Источники пока не задействованы — при необходимости обновите данные.';
+    };
+
+    const buildPlan = (topic, knowledge, memorySummary) => {
+        const steps = [];
+        if (topic) {
+            steps.push(`1. Формулирую задачу: ${topic}.`);
+        } else {
+            steps.push('1. Жду формулировку задачи, чтобы сфокусировать стратегию.');
+        }
+
+        if (knowledge?.combinedText) {
+            steps.push('2. Извлекаю ключевые факты из подключённых источников.');
+        } else if (knowledge?.errors?.length) {
+            steps.push('2. Интернет-источники сигнализируют о сбое, но стратегию всё равно построю.');
+        } else {
+            steps.push('2. Готова подключить интернет-источники по первому требованию.');
+        }
+
+        if (memorySummary) {
+            steps.push('3. Учитываю сохранённые инсайты и усиливаю ответ персональными нюансами.');
+        } else {
+            steps.push('3. Создаю свежую стратегию и начну фиксировать важные детали для памяти.');
+        }
+
+        steps.push('4. Сформулируйте следующее действие или уточнение — продолжу без задержек.');
+
+        return `🚀 План действий:\n${steps.join('\n')}`;
+    };
+
+    const respond = async (messages = []) => {
+        const now = clock();
+        const iso = now.toISOString();
+        const humanTime = now.toLocaleString('ru-RU', {
+            dateStyle: 'long',
+            timeStyle: 'medium'
+        });
+
+        const reversed = Array.isArray(messages) ? [...messages].reverse() : [];
+        const lastUserMessage = reversed.find((entry) => entry?.role === 'user');
+        const topic = lastUserMessage?.content?.trim() || '';
+        const data = await ensureAggregation(topic || aggregation.originalTopic);
+        const memorySummary = memoryVault.recall({ limit: 6, maxLength: 900 }) || '';
+
+        const intro = topic
+            ? `📝 Запрос: ${topic}`
+            : '📝 Жду ваш первый вопрос или инструкцию, чтобы запустить сверхрежим.';
+
+        const memoryBlock = memorySummary
+            ? `🧠 Из памяти Milana: ${limitText(memorySummary, 420)}`
+            : '🧠 Пока нет сохранённых инсайтов — мы начинаем с чистого листа.';
+
+        return [
+            `⚡ Режим Milana Super GPTb (free tier). Сейчас ${humanTime} (ISO: ${iso}).`,
+            intro,
+            buildKnowledgeBlock(data),
+            memoryBlock,
+            buildPlan(topic, data, memorySummary),
+            'Продолжайте — бесплатный режим уже отвечает без ключа. Для доступа к облачным моделям добавьте ключ в панели выше.'
+        ].join('\n\n');
+    };
+
+    return {
+        respond,
+        recordAggregation
+    };
+}

--- a/scripts/gpt.js
+++ b/scripts/gpt.js
@@ -1,0 +1,373 @@
+const requiredElement = (element, name) => {
+    if (!element) {
+        throw new Error(`Не найден элемент ${name} для интеграции с GPT.`);
+    }
+    return element;
+};
+
+const getStorageAPI = (storage) => {
+    if (!storage) {
+        return {
+            getItem: () => '',
+            setItem: () => {},
+            removeItem: () => {}
+        };
+    }
+    return storage;
+};
+
+const coerceUrl = (href) => {
+    if (!href) return null;
+    try {
+        return new URL(href);
+    } catch (error) {
+        return null;
+    }
+};
+
+export const DEFAULT_GPT_MODEL = 'gpt-4o-mini';
+
+export function createGptIntegration({
+    keyField,
+    saveButton,
+    testButton,
+    clearButton,
+    statusField,
+    storage = typeof window !== 'undefined' ? window.localStorage : undefined,
+    fetchImpl = typeof window !== 'undefined' ? window.fetch.bind(window) : undefined,
+    locationHref = typeof window !== 'undefined' ? window.location?.href : undefined,
+    autoApplyQuery = true,
+    freeTier
+} = {}) {
+    keyField = requiredElement(keyField, 'ввода ключа');
+    statusField = requiredElement(statusField, 'статуса ключа');
+
+    const storageAPI = getStorageAPI(storage);
+
+    if (!fetchImpl) {
+        throw new Error('Не найдена функция fetch для интеграции с GPT.');
+    }
+
+    let gptApiKey = '';
+    let busy = false;
+
+    const hasFreeTier = () => freeTier && typeof freeTier.respond === 'function';
+
+    const setStatus = (message, { error = false } = {}) => {
+        statusField.textContent = message || '';
+        statusField.style.color = error ? '#ff8fb7' : '#d4c7ff';
+    };
+
+    const syncField = (value) => {
+        if (!keyField) return;
+        keyField.value = value || '';
+    };
+
+    const persistKey = (value, { silent = false, message } = {}) => {
+        const inputValue = typeof value === 'string' ? value.trim() : '';
+        const fieldValue = keyField.value.trim();
+        const resolved = inputValue || fieldValue;
+
+        if (!resolved) {
+            return '';
+        }
+
+        if (resolved !== gptApiKey) {
+            gptApiKey = resolved;
+            storageAPI.setItem('gptApiKey', gptApiKey);
+        }
+
+        if (keyField.value !== gptApiKey) {
+            syncField(gptApiKey);
+        }
+
+        if (!silent) {
+            setStatus(message || 'Ключ сохранён в локальном хранилище браузера.');
+        }
+
+        return gptApiKey;
+    };
+
+    const toggleBusy = (value) => {
+        busy = Boolean(value);
+        [saveButton, testButton].forEach((button) => {
+            if (button) {
+                button.disabled = busy;
+            }
+        });
+    };
+
+    const loadFromStorage = () => {
+        gptApiKey = storageAPI.getItem('gptApiKey') || '';
+        syncField(gptApiKey);
+        if (gptApiKey) {
+            setStatus('Ключ загружен и готов к работе.');
+        } else if (hasFreeTier()) {
+            setStatus('Бесплатный режим Milana Super GPT активен. Добавьте ключ, чтобы подключить облачные модели.');
+        } else {
+            setStatus('Введите ключ, чтобы активировать GPT.');
+        }
+        return gptApiKey;
+    };
+
+    const clearKey = () => {
+        gptApiKey = '';
+        storageAPI.removeItem('gptApiKey');
+        syncField('');
+        if (hasFreeTier()) {
+            setStatus('Ключ удалён. Доступен бесплатный режим Super GPT без облачных моделей.');
+        } else {
+            setStatus('Ключ удалён из этого браузера.');
+        }
+        return gptApiKey;
+    };
+
+    const ensureKey = () => {
+        if (!gptApiKey) {
+            persistKey('', { silent: true });
+        }
+        if (!gptApiKey) {
+            const error = new Error('Добавьте ключ OpenAI API на панели выше.');
+            error.code = 'NO_KEY';
+            throw error;
+        }
+        return gptApiKey;
+    };
+
+    const formatError = (error) => {
+        if (!error) return 'Неизвестная ошибка GPT.';
+        if (error.code === 'NO_KEY') {
+            return 'Добавьте ключ OpenAI API в блоке «Интеграция с GPT». Ключ хранится только в вашем браузере.';
+        }
+        if (error.code === 'FREE_TIER_EMPTY') {
+            return 'Бесплатный режим Super GPT не смог подготовить ответ. Уточните запрос или добавьте ключ для облачных моделей.';
+        }
+        if (error.code === 'FREE_TIER_FAILED') {
+            return `Бесплатный режим Super GPT вернул ошибку: ${error.message}`;
+        }
+        return `Ошибка GPT: ${error.message}`;
+    };
+
+    const query = async (messages, {
+        temperature = 0.7,
+        model = DEFAULT_GPT_MODEL,
+        useFreeTier = false
+    } = {}) => {
+        if (gptApiKey) {
+            const key = ensureKey();
+            const response = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${key}`
+                },
+                body: JSON.stringify({
+                    model,
+                    messages,
+                    temperature
+                })
+            });
+
+            const data = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                const error = new Error(data?.error?.message || `Ошибка API (${response.status})`);
+                error.code = 'API_ERROR';
+                throw error;
+            }
+
+            const text = data?.choices?.[0]?.message?.content?.trim();
+            if (!text) {
+                const error = new Error('GPT вернул пустой ответ.');
+                error.code = 'EMPTY_RESPONSE';
+                throw error;
+            }
+            return text;
+        }
+
+        if (useFreeTier && hasFreeTier()) {
+            try {
+                const answer = await freeTier.respond(messages, { temperature, model });
+                const text = typeof answer === 'string' ? answer.trim() : '';
+                if (!text) {
+                    const error = new Error('Бесплатный движок не вернул ответ.');
+                    error.code = 'FREE_TIER_EMPTY';
+                    throw error;
+                }
+                return text;
+            } catch (error) {
+                if (error && typeof error === 'object' && 'code' in error) {
+                    throw error;
+                }
+                const wrapped = new Error(error instanceof Error ? error.message : String(error));
+                wrapped.code = 'FREE_TIER_FAILED';
+                throw wrapped;
+            }
+        }
+
+        ensureKey();
+    };
+
+    const buildDateTimeProbe = () => {
+        const now = new Date();
+        const isoStamp = now.toISOString();
+        const humanStamp = now.toLocaleString('ru-RU', {
+            dateStyle: 'long',
+            timeStyle: 'medium'
+        });
+
+        const messages = [
+            {
+                role: 'system',
+                content: 'Ты проверяешь интеграцию Milana Superintelligence с API OpenAI. Следуй инструкциям пользователя буквально.'
+            },
+            {
+                role: 'user',
+                content: [
+                    'Мы фиксируем текущее время в браузере.',
+                    `ISO-временная метка: ${isoStamp}.`,
+                    `В человеческом формате: ${humanStamp}.`,
+                    'Подтверди интеграцию, повторив ISO-метку и добавив короткое воодушевляющее сообщение на русском языке.'
+                ].join(' ')
+            }
+        ];
+
+        return { messages, isoStamp, humanStamp };
+    };
+
+    const runDateTimeProbe = async () => {
+        const { messages, isoStamp } = buildDateTimeProbe();
+        const answer = await query(messages, { temperature: 0 });
+        return { answer, isoStamp };
+    };
+
+    const testKey = async ({ candidate, message } = {}) => {
+        const candidateValue = typeof candidate === 'string' ? candidate.trim() : '';
+        const resolvedCandidate = candidateValue || keyField.value.trim();
+
+        if (!resolvedCandidate && !gptApiKey) {
+            setStatus('Введите ключ перед проверкой.', { error: true });
+            keyField.focus();
+            return false;
+        }
+
+        const previousKey = gptApiKey;
+        const persisted = persistKey(resolvedCandidate, { silent: true });
+        const isNewCandidate = persisted && persisted !== previousKey;
+        const statusMessage = message || (isNewCandidate
+            ? 'Ключ сохранён, запускаю проверку...'
+            : 'Запускаю проверку ключа...');
+        setStatus(statusMessage);
+
+        toggleBusy(true);
+        try {
+            const confirmation = await query([
+                { role: 'system', content: 'Ты лаконичный проверочный бот.' },
+                { role: 'user', content: 'Ответь одним словом «готово».' }
+            ], { temperature: 0 });
+            setStatus(`Ключ подтверждён. GPT ответил: ${confirmation}. Запрашиваю дату и время...`);
+            try {
+                const { answer, isoStamp } = await runDateTimeProbe();
+                setStatus(`Интеграция активна. GPT подтвердил время ${isoStamp}. Ответ: ${answer}`);
+                return true;
+            } catch (error) {
+                setStatus(`Ключ подтверждён, но проверка времени не удалась. ${formatError(error)}`, { error: true });
+                return false;
+            }
+        } catch (error) {
+            setStatus(formatError(error), { error: true });
+            return false;
+        } finally {
+            toggleBusy(false);
+        }
+    };
+
+    const applyKeyFromQuery = async () => {
+        const url = coerceUrl(locationHref);
+        if (!url) return;
+        const keyFromQuery = (url.searchParams.get('sk') || '').trim();
+        if (!keyFromQuery) return;
+
+        persistKey(keyFromQuery, { silent: true });
+        const prefix = 'Ключ из ссылки сохранён.';
+        const success = await testKey({
+            candidate: keyFromQuery,
+            message: `${prefix} Проверяю доступ...`
+        });
+        if (!success) {
+            const previousMessage = statusField.textContent || '';
+            const combined = previousMessage
+                ? `${prefix} ${previousMessage}`
+                : `${prefix} Проверьте корректность или повторите попытку.`;
+            setStatus(combined, { error: true });
+        }
+    };
+
+    const attachHandlers = () => {
+        if (saveButton) {
+            saveButton.addEventListener('click', async () => {
+                const savedKey = persistKey('', { silent: true });
+                if (!savedKey) {
+                    setStatus('Введите ключ перед сохранением.', { error: true });
+                    return;
+                }
+                await testKey({
+                    candidate: savedKey,
+                    message: 'Ключ сохранён, проверяю доступ...'
+                });
+            });
+        }
+
+        if (clearButton) {
+            clearButton.addEventListener('click', () => {
+                clearKey();
+            });
+        }
+
+        if (keyField) {
+            keyField.addEventListener('change', () => {
+                persistKey('', { silent: true });
+            });
+            keyField.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    if (saveButton && !saveButton.disabled) {
+                        saveButton.click();
+                    } else {
+                        testButton?.click?.();
+                    }
+                }
+            });
+        }
+
+        if (testButton) {
+            testButton.addEventListener('click', () => {
+                testKey();
+            });
+        }
+    };
+
+    const initialise = () => {
+        loadFromStorage();
+        attachHandlers();
+    };
+
+    initialise();
+
+    const ready = autoApplyQuery ? applyKeyFromQuery() : Promise.resolve();
+
+    return {
+        get key() {
+            return gptApiKey;
+        },
+        isBusy: () => busy,
+        persistKey,
+        clearKey,
+        loadFromStorage,
+        applyKeyFromQuery,
+        query,
+        testKey,
+        formatError,
+        runDateTimeProbe,
+        ready
+    };
+}

--- a/scripts/knowledge.js
+++ b/scripts/knowledge.js
@@ -1,0 +1,210 @@
+const getStorageAPI = (storage) => {
+    if (!storage) {
+        return {
+            getItem: () => null,
+            setItem: () => {},
+            removeItem: () => {}
+        };
+    }
+    return storage;
+};
+
+const sanitiseQuery = (query) => {
+    if (!query) return '';
+    return String(query).trim().slice(0, 160);
+};
+
+const mapSettled = (results, handlers) => results.map((result, index) => {
+    if (result.status === 'fulfilled') {
+        return handlers.fulfilled(result.value, index);
+    }
+    return handlers.rejected(result.reason, index);
+});
+
+const buildWikipediaConnector = () => ({
+    id: 'wikipedia',
+    label: 'Википедия',
+    description: 'Энциклопедические сведения из открытых источников.',
+    defaultEnabled: true,
+    async fetch(query, { fetchImpl }) {
+        const topic = sanitiseQuery(query).replace(/[\s]+/g, '_');
+        if (!topic) {
+            throw new Error('Нет темы для поиска на Википедии.');
+        }
+        const url = `https://ru.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(topic)}`;
+        const response = await fetchImpl(url, {
+            headers: { 'Accept': 'application/json' }
+        });
+        if (!response.ok) {
+            throw new Error('Википедия не нашла подходящий материал.');
+        }
+        const data = await response.json();
+        const summary = data.extract || data.description || '';
+        if (!summary) {
+            throw new Error('Википедия вернула пустой ответ.');
+        }
+        return summary.slice(0, 700);
+    }
+});
+
+const buildHackerNewsConnector = () => ({
+    id: 'hackernews',
+    label: 'Hacker News',
+    description: 'Тренды сообщества разработчиков и стартапов.',
+    defaultEnabled: true,
+    async fetch(query, { fetchImpl, limit = 3 }) {
+        const topic = sanitiseQuery(query);
+        if (!topic) {
+            throw new Error('Нет темы для поиска на Hacker News.');
+        }
+        const url = new URL('https://hn.algolia.com/api/v1/search');
+        url.searchParams.set('query', topic);
+        url.searchParams.set('tags', 'story');
+        url.searchParams.set('hitsPerPage', String(limit));
+        const response = await fetchImpl(url.toString(), { headers: { 'Accept': 'application/json' } });
+        if (!response.ok) {
+            throw new Error('Hacker News недоступен.');
+        }
+        const data = await response.json();
+        const hits = Array.isArray(data.hits) ? data.hits.slice(0, limit) : [];
+        if (!hits.length) {
+            throw new Error('На Hacker News нет подходящих тем.');
+        }
+        return hits.map((hit, index) => {
+            const title = hit?.title || hit?.story_title || 'Без названия';
+            const urlValue = hit?.url || hit?.story_url || '';
+            return `${index + 1}. ${title}${urlValue ? ` — ${urlValue}` : ''}`;
+        }).join('\n');
+    }
+});
+
+const buildOpenLibraryConnector = () => ({
+    id: 'openlibrary',
+    label: 'Open Library',
+    description: 'Каталог книг и исследований из открытой библиотеки Internet Archive.',
+    defaultEnabled: false,
+    async fetch(query, { fetchImpl, limit = 3 }) {
+        const topic = sanitiseQuery(query);
+        if (!topic) {
+            throw new Error('Нет темы для поиска книг в Open Library.');
+        }
+        const url = new URL('https://openlibrary.org/search.json');
+        url.searchParams.set('q', topic);
+        url.searchParams.set('limit', String(limit));
+        const response = await fetchImpl(url.toString(), { headers: { 'Accept': 'application/json' } });
+        if (!response.ok) {
+            throw new Error('Open Library недоступна.');
+        }
+        const data = await response.json();
+        const docs = Array.isArray(data.docs) ? data.docs.slice(0, limit) : [];
+        if (!docs.length) {
+            throw new Error('Open Library не нашла подходящих изданий.');
+        }
+        return docs.map((doc, index) => {
+            const title = doc?.title || 'Без названия';
+            const year = doc?.first_publish_year ? ` (${doc.first_publish_year})` : '';
+            const author = Array.isArray(doc?.author_name) && doc.author_name.length
+                ? ` — ${doc.author_name[0]}`
+                : '';
+            return `${index + 1}. ${title}${author}${year}`;
+        }).join('\n');
+    }
+});
+
+const defaultConnectors = [
+    buildWikipediaConnector(),
+    buildHackerNewsConnector(),
+    buildOpenLibraryConnector()
+];
+
+const STORAGE_KEY = 'gptKnowledgeHub';
+
+export function createKnowledgeHub({
+    storage = typeof window !== 'undefined' ? window.localStorage : undefined,
+    fetchImpl = typeof window !== 'undefined' ? window.fetch.bind(window) : undefined,
+    connectors = defaultConnectors
+} = {}) {
+    if (!fetchImpl) {
+        throw new Error('Не найдена функция fetch для доступа к интернет-источникам.');
+    }
+
+    const storageAPI = getStorageAPI(storage);
+    const listeners = new Set();
+
+    const safeParse = (value) => {
+        if (!value) return {};
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return {};
+        }
+    };
+
+    const loadState = () => safeParse(storageAPI.getItem(STORAGE_KEY));
+    const saveState = (state) => {
+        storageAPI.setItem(STORAGE_KEY, JSON.stringify(state));
+        listeners.forEach((listener) => {
+            try {
+                listener();
+            } catch (error) {
+                console.error('KnowledgeHub listener error', error); // eslint-disable-line no-console
+            }
+        });
+    };
+
+    const state = loadState();
+    if (!state.enabled) {
+        state.enabled = {};
+    }
+
+    const getConnectors = () => connectors.map((connector) => ({
+        ...connector,
+        enabled: state.enabled[connector.id] ?? connector.defaultEnabled !== false
+    }));
+
+    const setConnectorEnabled = (id, enabled) => {
+        state.enabled[id] = !!enabled;
+        saveState(state);
+    };
+
+    const subscribe = (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+    };
+
+    const gather = async (query, { limit = 3 } = {}) => {
+        const topic = sanitiseQuery(query);
+        const active = getConnectors().filter((connector) => connector.enabled);
+        if (!active.length || !topic) {
+            return { entries: [], combinedText: '', errors: topic ? [] : ['Не задан запрос для агрегации данных.'] };
+        }
+
+        const requests = active.map(async (connector) => {
+            const content = await connector.fetch(topic, { fetchImpl, limit });
+            return { id: connector.id, label: connector.label, content };
+        });
+
+        const settled = await Promise.allSettled(requests);
+        const entries = mapSettled(settled, {
+            fulfilled: (value) => value,
+            rejected: (reason, index) => ({
+                id: active[index].id,
+                label: active[index].label,
+                error: reason instanceof Error ? reason.message : String(reason)
+            })
+        });
+
+        const successful = entries.filter((entry) => !entry.error);
+        const combinedText = successful.map((entry) => `${entry.label}: ${entry.content}`).join('\n\n');
+        const errors = entries.filter((entry) => entry.error).map((entry) => `${entry.label}: ${entry.error}`);
+
+        return { entries, combinedText, errors };
+    };
+
+    return {
+        getConnectors,
+        setConnectorEnabled,
+        subscribe,
+        gather
+    };
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,762 @@
+import { createGptIntegration } from './gpt.js';
+import { createKnowledgeHub } from './knowledge.js';
+import { createMemoryVault } from './memory.js';
+import { createFreeTierEngine } from './free-tier.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const sections = document.querySelectorAll('.app-section');
+    const navButtons = document.querySelectorAll('#sidebar button[data-target]');
+    const newChatButton = document.getElementById('newChatButton');
+    const launchAksichat = document.getElementById('launchAksichat');
+    let resetChat = null;
+    let chatInputElement = null;
+
+    const highlightNewChat = (isActive) => {
+        if (newChatButton) {
+            newChatButton.classList.toggle('active', !!isActive);
+        }
+    };
+
+    const showSection = (id) => {
+        if (!id) return;
+        let found = false;
+        sections.forEach(section => {
+            const match = section.id === id;
+            section.style.display = match ? 'block' : 'none';
+            if (match) found = true;
+        });
+        if (!found) return;
+        navButtons.forEach(button => {
+            button.classList.toggle('active', button.dataset.target === id);
+        });
+        highlightNewChat(id === 'aksichat');
+    };
+
+    window.showSection = showSection;
+
+    if (newChatButton) {
+        newChatButton.addEventListener('click', () => {
+            showSection('aksichat');
+            if (typeof resetChat === 'function') {
+                resetChat({ greet: true });
+            }
+            if (chatInputElement) {
+                chatInputElement.focus();
+            }
+            newChatButton.blur();
+        });
+    }
+
+    navButtons.forEach(button => {
+        button.addEventListener('click', () => showSection(button.dataset.target));
+    });
+
+    if (navButtons.length) {
+        showSection(navButtons[0].dataset.target);
+    }
+
+    const knowledgeHub = createKnowledgeHub();
+    const memoryVault = createMemoryVault();
+    const freeTierEngine = createFreeTierEngine({ knowledgeHub, memoryVault });
+
+    const gptIntegration = createGptIntegration({
+        keyField: document.getElementById('gptApiKey'),
+        saveButton: document.getElementById('gptSaveKey'),
+        testButton: document.getElementById('gptTestKey'),
+        clearButton: document.getElementById('gptClearKey'),
+        statusField: document.getElementById('gptKeyStatus'),
+        freeTier: freeTierEngine
+    });
+
+    const queryGPT = (...args) => gptIntegration.query(...args);
+    const formatGptError = (error) => gptIntegration.formatError(error);
+
+    const knowledgeSourcesList = document.getElementById('knowledgeSourcesList');
+    const knowledgePreview = document.getElementById('knowledgePreview');
+    const knowledgeStatus = document.getElementById('knowledgeStatus');
+    const knowledgeRefreshButton = document.getElementById('knowledgeRefreshButton');
+    const memoryStatus = document.getElementById('memoryStatus');
+    const memoryClearButton = document.getElementById('memoryClearButton');
+
+    const setKnowledgeStatus = (message, isError = false) => {
+        if (!knowledgeStatus) return;
+        knowledgeStatus.textContent = message || '';
+        knowledgeStatus.style.color = isError ? '#ff8fb7' : '#d4c7ff';
+    };
+
+    const updateMemoryStatus = () => {
+        if (!memoryStatus) return;
+        const summary = memoryVault.recall({ limit: 6, maxLength: 900 });
+        memoryStatus.textContent = summary
+            ? `Долгосрочная память Milana GPTb:\n${summary}`
+            : 'Память пуста. Начните диалог, и Milana сохранит ключевые инсайты.';
+    };
+
+    const renderKnowledgeSources = () => {
+        if (!knowledgeSourcesList) return;
+        knowledgeSourcesList.innerHTML = '';
+        knowledgeHub.getConnectors().forEach((connector) => {
+            const item = document.createElement('li');
+            item.className = 'knowledge-source';
+
+            const label = document.createElement('label');
+            label.className = 'knowledge-source-label';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = connector.enabled;
+            checkbox.addEventListener('change', () => {
+                knowledgeHub.setConnectorEnabled(connector.id, checkbox.checked);
+            });
+
+            const title = document.createElement('span');
+            title.className = 'knowledge-source-title';
+            title.textContent = connector.label;
+
+            const description = document.createElement('span');
+            description.className = 'knowledge-source-description';
+            description.textContent = connector.description;
+
+            const textContainer = document.createElement('div');
+            textContainer.className = 'knowledge-source-text';
+            textContainer.appendChild(title);
+            textContainer.appendChild(description);
+
+            label.appendChild(checkbox);
+            label.appendChild(textContainer);
+            item.appendChild(label);
+            knowledgeSourcesList.appendChild(item);
+        });
+    };
+
+    knowledgeHub.subscribe(renderKnowledgeSources);
+    renderKnowledgeSources();
+    updateMemoryStatus();
+
+    const formatKnowledgeEntries = (entries) => {
+        if (!entries.length) {
+            return 'Активируйте источники или уточните запрос, чтобы получить внешние данные.';
+        }
+        return entries.map((entry) => {
+            if (entry.error) {
+                return `⚠️ ${entry.label}: ${entry.error}`;
+            }
+            return `# ${entry.label}\n${entry.content}`;
+        }).join('\n\n');
+    };
+
+    const refreshKnowledgePreview = async (query) => {
+        if (!knowledgePreview) return { combinedText: '', entries: [], errors: [] };
+        knowledgePreview.textContent = 'Подключаем интернет-источники...';
+        try {
+            const result = await knowledgeHub.gather(query, { limit: 5 });
+            freeTierEngine.recordAggregation({
+                topic: query,
+                combinedText: result.combinedText,
+                entries: result.entries,
+                errors: result.errors
+            });
+            knowledgePreview.textContent = formatKnowledgeEntries(result.entries);
+            if (result.errors.length) {
+                setKnowledgeStatus(result.errors[0], true);
+            } else if (result.entries.length) {
+                setKnowledgeStatus('Интернет-данные синхронизированы.', false);
+            } else {
+                setKnowledgeStatus('Источники активны, но не нашли совпадений.', false);
+            }
+            return result;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            knowledgePreview.textContent = `Ошибка агрегации данных: ${message}`;
+            setKnowledgeStatus(message, true);
+            freeTierEngine.recordAggregation({
+                topic: query,
+                combinedText: '',
+                entries: [],
+                errors: [message]
+            });
+            return { combinedText: '', entries: [], errors: [message] };
+        }
+    };
+
+    if (knowledgeRefreshButton) {
+        knowledgeRefreshButton.addEventListener('click', async () => {
+            const query = chatInputElement?.value?.trim() || 'искусственный интеллект';
+            await refreshKnowledgePreview(query);
+        });
+    }
+
+    if (memoryClearButton) {
+        memoryClearButton.addEventListener('click', () => {
+            memoryVault.clear();
+            updateMemoryStatus();
+        });
+    }
+
+    refreshKnowledgePreview('искусственный интеллект');
+
+    const moodMirrorButton = document.getElementById('moodMirrorButton');
+    if (moodMirrorButton) {
+        const select = document.getElementById('moodMirrorSelect');
+        const display = document.getElementById('moodMirrorDisplay');
+        moodMirrorButton.addEventListener('click', () => {
+            const mood = select.value;
+            let color = '';
+            let text = '';
+            switch (mood) {
+                case 'happy': color = '#ffe066'; text = 'Вы счастливы!'; break;
+                case 'sad': color = '#74c0fc'; text = 'Вы грустите.'; break;
+                case 'angry': color = '#fa5252'; text = 'Вы злитесь.'; break;
+                case 'calm': color = '#b2f2bb'; text = 'Вы спокойны.'; break;
+            }
+            display.style.backgroundColor = color;
+            display.innerText = text;
+        });
+    }
+
+    const mindMirrorSave = document.getElementById('mindMirrorSave');
+    if (mindMirrorSave) {
+        const reflections = [
+            'Попробуйте выразить благодарность за что-то.',
+            'Сделайте глубокий вдох и расслабьтесь.',
+            'Запишите положительный момент из дня.',
+            'Уделите время отдыху и восстановлению.'
+        ];
+        const entryField = document.getElementById('mindMirrorEntry');
+        const entriesContainer = document.getElementById('mindMirrorEntries');
+        const reflectionOutput = document.getElementById('mindMirrorReflection');
+
+        const loadEntries = () => {
+            const entries = JSON.parse(localStorage.getItem('mindEntries') || '[]');
+            entriesContainer.innerHTML = '';
+            entries.forEach((entry, index) => {
+                const card = document.createElement('div');
+                card.className = 'card';
+                card.innerHTML = `<strong>Запись ${index + 1}</strong><p>${entry}</p>`;
+                entriesContainer.appendChild(card);
+            });
+        };
+
+        mindMirrorSave.addEventListener('click', () => {
+            const text = entryField.value.trim();
+            if (!text) return;
+            const entries = JSON.parse(localStorage.getItem('mindEntries') || '[]');
+            entries.push(text);
+            localStorage.setItem('mindEntries', JSON.stringify(entries));
+            entryField.value = '';
+            loadEntries();
+            const reflection = reflections[Math.floor(Math.random() * reflections.length)];
+            reflectionOutput.innerText = `Совет: ${reflection}`;
+        });
+
+        loadEntries();
+    }
+
+    const mindLinkButton = document.getElementById('mindLinkButton');
+    if (mindLinkButton) {
+        const progress = document.getElementById('mindLinkProgress');
+        const status = document.getElementById('mindLinkStatus');
+        mindLinkButton.addEventListener('click', () => {
+            const value = Math.floor(Math.random() * 101);
+            progress.value = value;
+            if (value < 33) status.innerText = 'Низкая активность';
+            else if (value < 66) status.innerText = 'Средняя активность';
+            else status.innerText = 'Высокая активность';
+        });
+    }
+
+    const healthScanButton = document.getElementById('healthScanButton');
+    if (healthScanButton) {
+        healthScanButton.addEventListener('click', () => {
+            const heart = parseInt(document.getElementById('healthPulse').value, 10);
+            const sys = parseInt(document.getElementById('healthSystolic').value, 10);
+            let message = '';
+            if (heart > 100) message += 'Повышенный пульс. ';
+            else if (heart < 60) message += 'Низкий пульс. ';
+            else message += 'Пульс в норме. ';
+            if (sys > 140) message += 'Высокое давление. ';
+            else if (sys < 90) message += 'Низкое давление. ';
+            else message += 'Давление в норме.';
+            document.getElementById('healthResult').innerText = message.trim();
+        });
+    }
+
+    const mentorButton = document.getElementById('mentorAdviceButton');
+    if (mentorButton) {
+        const advices = [
+            'Верить в себя — первый шаг к успеху.',
+            'Каждый день учитесь чему-то новому.',
+            'Планируйте и ставьте маленькие цели.',
+            'Не бойтесь ошибок — они учат.'
+        ];
+        const adviceOutput = document.getElementById('mentorAdvice');
+        mentorButton.addEventListener('click', () => {
+            const advice = advices[Math.floor(Math.random() * advices.length)];
+            adviceOutput.innerText = advice;
+        });
+    }
+
+    const familyAddButton = document.getElementById('familyAddButton');
+    if (familyAddButton) {
+        const nameField = document.getElementById('familyEventName');
+        const dateField = document.getElementById('familyEventDate');
+        const table = document.getElementById('familyEventsTable');
+
+        const loadEvents = () => {
+            const events = JSON.parse(localStorage.getItem('familyEvents') || '[]');
+            table.innerHTML = '<tr><th>Событие</th><th>Дата</th></tr>';
+            events.forEach(event => {
+                const row = document.createElement('tr');
+                row.innerHTML = `<td>${event.name}</td><td>${event.date}</td>`;
+                table.appendChild(row);
+            });
+        };
+
+        familyAddButton.addEventListener('click', () => {
+            const name = nameField.value.trim();
+            const date = dateField.value;
+            if (!name || !date) return;
+            const events = JSON.parse(localStorage.getItem('familyEvents') || '[]');
+            events.push({ name, date });
+            localStorage.setItem('familyEvents', JSON.stringify(events));
+            nameField.value = '';
+            dateField.value = '';
+            loadEvents();
+        });
+
+        loadEvents();
+    }
+
+    const auraMoodButton = document.getElementById('auraMoodButton');
+    if (auraMoodButton) {
+        const select = document.getElementById('auraMoodSelect');
+        const display = document.getElementById('auraMoodDisplay');
+        auraMoodButton.addEventListener('click', () => {
+            const mood = select.value;
+            let color = '';
+            let text = '';
+            switch (mood) {
+                case 'happy': color = '#ff922b'; text = 'Ваша аура сияет радостью!'; break;
+                case 'sad': color = '#4dabf7'; text = 'Ваша аура спокойна и задумчива.'; break;
+                case 'angry': color = '#ff6b6b'; text = 'Аура насыщена сильной энергией.'; break;
+                case 'calm': color = '#69db7c'; text = 'Аура ровная и гармоничная.'; break;
+            }
+            display.style.backgroundColor = color;
+            display.innerText = text;
+        });
+    }
+
+    const loveMatchButton = document.getElementById('loveMatchButton');
+    if (loveMatchButton) {
+        const matches = ['Алексей', 'Ольга', 'Сергей', 'Мария', 'Иван', 'Екатерина'];
+        loveMatchButton.addEventListener('click', () => {
+            const name = document.getElementById('loveYourName').value.trim();
+            const preference = document.getElementById('lovePreference').value.trim();
+            const match = matches[Math.floor(Math.random() * matches.length)];
+            const prefix = name ? `${name}, ` : '';
+            const suffix = preference ? ` (учитывая предпочтение: ${preference})` : '';
+            document.getElementById('loveMatchResult').innerText = `${prefix}ваша совместимость на сегодня: ${match}${suffix}`;
+        });
+    }
+
+    const moodRadioButton = document.getElementById('moodRadioButton');
+    if (moodRadioButton) {
+        const playlists = {
+            happy: ['Happy Song 1', 'Joyful Tune 2', 'Sunny Day'],
+            sad: ['Melancholic Melody', 'Slow Ballad', 'Rainy Thoughts'],
+            angry: ['Rock Anthem', 'Metal Fury', 'Energetic Beat'],
+            calm: ['Peaceful Piano', 'Relaxing Waves', 'Soft Guitar']
+        };
+        const select = document.getElementById('moodRadioSelect');
+        const list = document.getElementById('moodRadioList');
+        moodRadioButton.addEventListener('click', () => {
+            const mood = select.value;
+            list.innerHTML = '';
+            playlists[mood].forEach(song => {
+                const item = document.createElement('li');
+                item.textContent = song;
+                list.appendChild(item);
+            });
+        });
+    }
+
+    const cartCount = document.getElementById('cartCount');
+    const productList = document.getElementById('productList');
+    if (cartCount && productList) {
+        const products = [
+            { name: 'Смартфон', price: 500 },
+            { name: 'Наушники', price: 50 },
+            { name: 'Ноутбук', price: 800 },
+            { name: 'Фитнес-браслет', price: 100 }
+        ];
+        let cart = JSON.parse(localStorage.getItem('shopCart') || '[]');
+
+        const updateCart = () => {
+            cartCount.innerText = `В корзине: ${cart.length}`;
+        };
+
+        const renderProducts = () => {
+            productList.innerHTML = '';
+            products.forEach((product, index) => {
+                const card = document.createElement('div');
+                card.className = 'card';
+                const title = document.createElement('p');
+                title.innerHTML = `<strong>${product.name}</strong> — ${product.price}₽`;
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.textContent = 'Добавить в корзину';
+                button.addEventListener('click', () => {
+                    cart.push(product);
+                    localStorage.setItem('shopCart', JSON.stringify(cart));
+                    updateCart();
+                });
+                card.appendChild(title);
+                card.appendChild(button);
+                productList.appendChild(card);
+            });
+        };
+
+        updateCart();
+        renderProducts();
+    }
+
+    const stylistButton = document.getElementById('stylistButton');
+    if (stylistButton) {
+        const outfits = [
+            'Белая рубашка с джинсами — классика, которая подходит всем.',
+            'Пастельные тона и лёгкие ткани — отличный выбор для весны.',
+            'Спортивный костюм сочетается с кроссовками для активного дня.',
+            'Деловой костюм подчеркнёт вашу уверенность.'
+        ];
+        const output = document.getElementById('stylistAdvice');
+        const preferenceField = document.getElementById('stylistPreference');
+        stylistButton.addEventListener('click', () => {
+            const advice = outfits[Math.floor(Math.random() * outfits.length)];
+            const preference = preferenceField.value.trim();
+            output.innerText = preference ? `${advice} Учтите ваш выбор: ${preference}.` : advice;
+        });
+    }
+
+    const ecoAnalyzeButton = document.getElementById('ecoAnalyzeButton');
+    if (ecoAnalyzeButton) {
+        ecoAnalyzeButton.addEventListener('click', () => {
+            const light = parseFloat(document.getElementById('ecoLight').value);
+            const noise = parseFloat(document.getElementById('ecoNoise').value);
+            const co2 = parseFloat(document.getElementById('ecoCO2').value);
+            let result = '';
+            result += light >= 300 && light <= 500 ? 'Хорошая освещённость. ' : 'Плохая освещённость. ';
+            result += noise <= 50 ? 'Шум в норме. ' : 'Шум высокий. ';
+            result += co2 <= 1000 ? 'CO₂ в норме.' : 'Повышенный CO₂.';
+            document.getElementById('ecoResult').innerText = result.trim();
+        });
+    }
+
+    const dreamSaveButton = document.getElementById('dreamSaveButton');
+    if (dreamSaveButton) {
+        const entryField = document.getElementById('dreamEntry');
+        const container = document.getElementById('dreamEntries');
+
+        const loadEntries = () => {
+            const entries = JSON.parse(localStorage.getItem('dreamEntries') || '[]');
+            container.innerHTML = '';
+            entries.forEach((entry, index) => {
+                const card = document.createElement('div');
+                card.className = 'card';
+                card.innerHTML = `<strong>Запись ${index + 1}</strong><p>${entry}</p>`;
+                container.appendChild(card);
+            });
+        };
+
+        dreamSaveButton.addEventListener('click', () => {
+            const text = entryField.value.trim();
+            if (!text) return;
+            const entries = JSON.parse(localStorage.getItem('dreamEntries') || '[]');
+            entries.push(text);
+            localStorage.setItem('dreamEntries', JSON.stringify(entries));
+            entryField.value = '';
+            loadEntries();
+        });
+
+        loadEntries();
+    }
+
+    const companionTalkButton = document.getElementById('companionTalkButton');
+    const companionFeedButton = document.getElementById('companionFeedButton');
+    if (companionTalkButton && companionFeedButton) {
+        let happiness = 50;
+        const phrases = [
+            'Приятно с вами общаться!',
+            'Надеюсь, у вас хороший день!',
+            'Я всегда рядом.',
+            'Расскажите мне что-то новое.'
+        ];
+        const status = document.getElementById('companionStatus');
+        const message = document.getElementById('companionMessage');
+
+        const updateCompanion = () => {
+            status.innerText = `Уровень радости: ${happiness}%`;
+        };
+
+        companionTalkButton.addEventListener('click', () => {
+            const phrase = phrases[Math.floor(Math.random() * phrases.length)];
+            message.innerText = phrase;
+            happiness = Math.min(100, happiness + 5);
+            updateCompanion();
+        });
+
+        companionFeedButton.addEventListener('click', () => {
+            message.innerText = 'Спасибо за еду! :)';
+            happiness = Math.min(100, happiness + 10);
+            updateCompanion();
+        });
+
+        updateCompanion();
+    }
+
+    const dressUpButton = document.getElementById('dressUpButton');
+    if (dressUpButton) {
+        const select = document.getElementById('dressUpSelect');
+        const result = document.getElementById('dressUpResult');
+        dressUpButton.addEventListener('click', () => {
+            const item = select.value;
+            result.innerText = item ? `Вы выбрали: ${item}` : '';
+        });
+    }
+
+    const globalIdButton = document.getElementById('globalIdButton');
+    if (globalIdButton) {
+        const nameField = document.getElementById('globalIdName');
+        const numberField = document.getElementById('globalIdNumber');
+        const card = document.getElementById('globalIdCard');
+        globalIdButton.addEventListener('click', () => {
+            const name = nameField.value.trim();
+            const number = numberField.value.trim();
+            if (!name || !number) return;
+            card.innerHTML = `<p><strong>Имя:</strong> ${name}</p><p><strong>ID:</strong> ${number}</p>`;
+        });
+    }
+
+    const chatSendButton = document.getElementById('chatSendButton');
+    if (chatSendButton) {
+        const input = document.getElementById('chatInput');
+        const box = document.getElementById('chatBox');
+        const chatStatus = document.getElementById('chatStatus');
+        const introMessage = 'Привет! Я Милана Hyper AI. Помогаю мыслить стратегически, создавать код и воплощать идеи лучше любых стандартных моделей.';
+        const chatHistory = [
+            { role: 'system', content: 'Ты — Милана, сверхинтеллект AKSI. Отвечай по-русски, вдохновляюще и по делу. Предлагай стратегии, идеи и конкретные шаги, оставаясь доброжелательной и уверенной.' }
+        ];
+        chatInputElement = input;
+
+        const appendMessage = (role, text) => {
+            if (!box) return;
+            const block = document.createElement('div');
+            block.className = `chat-message ${role === 'user' ? 'from-user' : 'from-assistant'}`;
+
+            const avatar = document.createElement('div');
+            avatar.className = 'chat-avatar';
+            avatar.textContent = role === 'user' ? 'Вы' : 'AI';
+
+            const bubble = document.createElement('div');
+            bubble.className = 'chat-bubble';
+            bubble.textContent = text;
+
+            block.appendChild(avatar);
+            block.appendChild(bubble);
+            box.appendChild(block);
+            box.scrollTop = box.scrollHeight;
+        };
+
+        const setChatStatus = (message, isError = false) => {
+            if (!chatStatus) return;
+            chatStatus.textContent = message || '';
+            chatStatus.style.color = isError ? '#ff8fb7' : '#d4c7ff';
+        };
+
+        resetChat = ({ greet = false } = {}) => {
+            chatHistory.splice(1);
+            if (box) {
+                box.innerHTML = '';
+            }
+            if (greet) {
+                appendMessage('assistant', introMessage);
+                chatHistory.push({ role: 'assistant', content: introMessage });
+                setChatStatus('Я на связи для нового диалога.');
+            } else {
+                setChatStatus('');
+            }
+            chatSendButton.disabled = false;
+            updateMemoryStatus();
+        };
+
+        resetChat({ greet: true });
+
+        const sendMessage = async () => {
+            const text = input?.value.trim();
+            if (!text) return;
+            appendMessage('user', text);
+            if (input) input.value = '';
+            chatSendButton.disabled = true;
+            setChatStatus('Синхронизирую память и интернет-данные...');
+
+            try {
+                const { combinedText } = await refreshKnowledgePreview(text);
+                const runtimeMessages = [...chatHistory];
+                const memoryContext = memoryVault.recall({ limit: 6, maxLength: 900 });
+                if (memoryContext) {
+                    runtimeMessages.push({
+                        role: 'system',
+                        content: `Долгосрочная память Milana GPTb:\n${memoryContext}`
+                    });
+                }
+                if (combinedText) {
+                    runtimeMessages.push({
+                        role: 'system',
+                        content: `Свежие внешние данные:\n${combinedText}`
+                    });
+                }
+
+                const userMessage = { role: 'user', content: text };
+                runtimeMessages.push(userMessage);
+                chatHistory.push(userMessage);
+
+                setChatStatus('Запрашиваем ответ у Milana Hyper AI...');
+                const reply = await queryGPT(runtimeMessages, { useFreeTier: true });
+                chatHistory.push({ role: 'assistant', content: reply });
+                appendMessage('assistant', reply);
+                memoryVault.remember({ user: text, assistant: reply });
+                updateMemoryStatus();
+                setChatStatus('Готово.');
+            } catch (error) {
+                const message = formatGptError(error);
+                setChatStatus(message, true);
+                const fallback = error?.code === 'NO_KEY'
+                    ? 'Добавьте ключ OpenAI API в блоке выше, чтобы я смог отвечать.'
+                    : 'Не удалось получить ответ от GPT. Попробуйте ещё раз.';
+                appendMessage('assistant', fallback);
+                chatHistory.push({ role: 'assistant', content: fallback });
+            } finally {
+                chatSendButton.disabled = false;
+                if (input) input.focus();
+            }
+        };
+
+        chatSendButton.addEventListener('click', sendMessage);
+        if (input) {
+            input.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                    event.preventDefault();
+                    sendMessage();
+                }
+            });
+        }
+
+        if (launchAksichat) {
+            launchAksichat.addEventListener('click', () => {
+                showSection('aksichat');
+                if (input) input.focus();
+            });
+        }
+    }
+
+    const lifeCalcButton = document.getElementById('lifeCalcButton');
+    if (lifeCalcButton) {
+        lifeCalcButton.addEventListener('click', () => {
+            const weight = parseFloat(document.getElementById('lifeWeight').value);
+            const height = parseFloat(document.getElementById('lifeHeight').value) / 100;
+            if (!weight || !height) return;
+            const bmi = weight / (height * height);
+            let category = '';
+            if (bmi < 18.5) category = 'Недостаток веса';
+            else if (bmi < 25) category = 'Норма';
+            else if (bmi < 30) category = 'Избыточный вес';
+            else category = 'Ожирение';
+            document.getElementById('lifeBmiResult').innerText = `ИМТ: ${bmi.toFixed(1)} — ${category}`;
+        });
+    }
+
+    const capsuleSaveButton = document.getElementById('capsuleSaveButton');
+    const capsuleOpenButton = document.getElementById('capsuleOpenButton');
+    if (capsuleSaveButton && capsuleOpenButton) {
+        const messageField = document.getElementById('capsuleMessage');
+        const dateField = document.getElementById('capsuleDate');
+        const container = document.getElementById('capsuleList');
+
+        const loadCapsules = () => JSON.parse(localStorage.getItem('timeCapsules') || '[]');
+
+        const renderCapsules = () => {
+            const now = new Date();
+            container.innerHTML = '';
+            loadCapsules().forEach(capsule => {
+                const openDate = new Date(capsule.date);
+                if (openDate <= now) {
+                    const card = document.createElement('div');
+                    card.className = 'card';
+                    card.innerHTML = `<p>${capsule.msg}</p><small>Дата создания: ${capsule.date}</small>`;
+                    container.appendChild(card);
+                }
+            });
+        };
+
+        capsuleSaveButton.addEventListener('click', () => {
+            const message = messageField.value.trim();
+            const date = dateField.value;
+            if (!message || !date) return;
+            const capsules = loadCapsules();
+            capsules.push({ msg: message, date });
+            localStorage.setItem('timeCapsules', JSON.stringify(capsules));
+            messageField.value = '';
+            dateField.value = '';
+        });
+
+        capsuleOpenButton.addEventListener('click', renderCapsules);
+    }
+
+    const telehelpButton = document.getElementById('telehelpButton');
+    if (telehelpButton) {
+        telehelpButton.addEventListener('click', () => {
+            document.getElementById('telehelpResult').innerText = 'Запрос SOS отправлен! Дождитесь помощи.';
+        });
+    }
+
+    const storyButton = document.getElementById('storyButton');
+    if (storyButton) {
+        const templates = [
+            'Однажды {prompt}, и это привело к удивительному приключению, полному неожиданных поворотов.',
+            'История о {prompt} началась в туманное утро, когда мир перевернулся с ног на голову.',
+            '{prompt} — герой, который доказал, что даже самые смелые мечты могут стать реальностью.',
+            'В далёком королевстве жил {prompt}, и однажды он нашёл секрет, изменивший всё.'
+        ];
+        const promptField = document.getElementById('storyPrompt');
+        const output = document.getElementById('storyOutput');
+        const storyStatus = document.getElementById('storyStatus');
+
+        const setStoryStatus = (message, isError = false) => {
+            if (!storyStatus) return;
+            storyStatus.textContent = message || '';
+            storyStatus.style.color = isError ? '#ff8fb7' : '#d4c7ff';
+        };
+
+        storyButton.addEventListener('click', async () => {
+            const prompt = promptField?.value.trim();
+            if (!prompt) return;
+            setStoryStatus('Обращаемся к GPT...');
+            storyButton.disabled = true;
+
+            try {
+                const story = await queryGPT([
+                    { role: 'system', content: 'Ты — автор вдохновляющих коротких историй на русском языке.' },
+                    { role: 'user', content: `Напиши цельный вдохновляющий рассказ объёмом 120–180 слов по теме: "${prompt}". Сделай финал позитивным.` }
+                ], { temperature: 0.8 });
+                if (output) output.textContent = story;
+                setStoryStatus('Готово.');
+            } catch (error) {
+                const message = formatGptError(error);
+                setStoryStatus(`${message} Показан офлайн-шаблон.`, true);
+                const template = templates[Math.floor(Math.random() * templates.length)];
+                if (output) output.textContent = template.replace('{prompt}', prompt);
+            } finally {
+                storyButton.disabled = false;
+            }
+        });
+    }
+});

--- a/scripts/memory.js
+++ b/scripts/memory.js
@@ -1,0 +1,93 @@
+const getStorageAPI = (storage) => {
+    if (!storage) {
+        return {
+            getItem: () => null,
+            setItem: () => {},
+            removeItem: () => {}
+        };
+    }
+    return storage;
+};
+
+const STORAGE_KEY = 'gptLongTermMemory';
+
+const sanitise = (value) => {
+    if (!value) return '';
+    return String(value).replace(/[\s\n]+/g, ' ').trim();
+};
+
+const truncate = (text, maxLength) => {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return `${text.slice(0, maxLength - 1)}…`;
+};
+
+export function createMemoryVault({
+    storage = typeof window !== 'undefined' ? window.localStorage : undefined,
+    maxEntries = 40
+} = {}) {
+    const storageAPI = getStorageAPI(storage);
+
+    const read = () => {
+        try {
+            const stored = storageAPI.getItem(STORAGE_KEY);
+            if (!stored) return [];
+            const parsed = JSON.parse(stored);
+            if (!Array.isArray(parsed)) return [];
+            return parsed;
+        } catch (error) {
+            return [];
+        }
+    };
+
+    const write = (entries) => {
+        try {
+            storageAPI.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-maxEntries)));
+        } catch (error) {
+            // storage может быть недоступен, просто игнорируем
+        }
+    };
+
+    const remember = ({ user, assistant, timestamp = new Date().toISOString() }) => {
+        const cleanUser = sanitise(user);
+        const cleanAssistant = sanitise(assistant);
+        if (!cleanUser && !cleanAssistant) {
+            return;
+        }
+        const entries = read();
+        entries.push({ user: cleanUser, assistant: cleanAssistant, timestamp });
+        write(entries);
+    };
+
+    const clear = () => {
+        try {
+            storageAPI.removeItem(STORAGE_KEY);
+        } catch (error) {
+            // ignore
+        }
+    };
+
+    const formatEntry = (entry, index) => {
+        const date = entry.timestamp ? new Date(entry.timestamp).toLocaleString('ru-RU') : `Запись ${index + 1}`;
+        const user = truncate(entry.user || 'Вопрос без текста', 140);
+        const assistant = truncate(entry.assistant || 'Ответ отсутствует', 180);
+        return `${date}: ${user} → ${assistant}`;
+    };
+
+    const recall = ({ limit = 4, maxLength = 900 } = {}) => {
+        const entries = read();
+        if (!entries.length) return '';
+        const latest = entries.slice(-limit);
+        const formatted = latest.map(formatEntry);
+        return truncate(formatted.join('\n'), maxLength);
+    };
+
+    const exportAll = () => read();
+
+    return {
+        remember,
+        recall,
+        clear,
+        exportAll
+    };
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,565 @@
+:root {
+    --bg: #05010f;
+    --bg-gradient: radial-gradient(circle at top left, rgba(96, 48, 162, 0.55), rgba(5, 1, 15, 0.95) 55%);
+    --sidebar-bg: rgba(12, 6, 33, 0.92);
+    --sidebar-border: rgba(180, 140, 255, 0.28);
+    --sidebar-text: #d9d1ff;
+    --sidebar-muted: rgba(211, 201, 255, 0.7);
+    --content-bg: rgba(11, 5, 28, 0.7);
+    --card-bg: rgba(20, 8, 48, 0.72);
+    --card-border: rgba(165, 117, 255, 0.35);
+    --accent: #a76dff;
+    --accent-strong: #c692ff;
+    --text: #fefbff;
+    --text-muted: rgba(235, 223, 255, 0.76);
+    --danger: #ff8fb7;
+    --surface-shadow: 0 24px 60px rgba(37, 9, 94, 0.4);
+}
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: var(--bg-gradient);
+    color: var(--text);
+}
+header {
+    padding: 1.75rem 3rem 1.5rem;
+    background: transparent;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+}
+header h1 {
+    margin: 0;
+    font-size: 1.8rem;
+    letter-spacing: 0.04em;
+}
+header span {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+.header-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+#layout {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+}
+#sidebar {
+    width: 280px;
+    background: var(--sidebar-bg);
+    border-right: 1px solid var(--sidebar-border);
+    display: flex;
+    flex-direction: column;
+    color: var(--sidebar-text);
+}
+.sidebar-header {
+    padding: 1.5rem 1.75rem 1rem;
+    border-bottom: 1px solid var(--sidebar-border);
+}
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    margin-bottom: 1.25rem;
+}
+.brand-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.9), rgba(102, 64, 255, 0.8));
+    box-shadow: 0 12px 28px rgba(104, 66, 255, 0.35);
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+.brand-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+.brand-title strong {
+    font-size: 1.05rem;
+    letter-spacing: 0.08em;
+}
+.brand-title span {
+    color: var(--sidebar-muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+}
+#newChatButton {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(167, 109, 255, 0.3);
+    background: rgba(167, 109, 255, 0.18);
+    color: var(--text);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+#newChatButton:hover,
+#newChatButton:focus {
+    outline: none;
+    transform: translateY(-1px);
+    background: rgba(167, 109, 255, 0.32);
+    box-shadow: 0 16px 36px rgba(167, 109, 255, 0.25);
+}
+#newChatButton.active {
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.7), rgba(102, 64, 255, 0.75));
+    border-color: rgba(167, 109, 255, 0.8);
+    box-shadow: 0 18px 42px rgba(118, 72, 255, 0.4);
+}
+#sidebar .sidebar-section {
+    padding: 1.25rem 1.75rem 1.5rem;
+    flex: 1;
+    overflow-y: auto;
+}
+.sidebar-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--sidebar-muted);
+    margin: 0 0 1rem 0;
+}
+#sidebar ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+#sidebar li {
+    margin: 0;
+}
+#sidebar button {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--sidebar-muted);
+    text-align: left;
+    font-size: 0.92rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+#sidebar button::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.3);
+    flex-shrink: 0;
+}
+#sidebar button:hover,
+#sidebar button:focus {
+    border-color: rgba(167, 109, 255, 0.35);
+    background: rgba(167, 109, 255, 0.12);
+    color: var(--text);
+    outline: none;
+    transform: translateX(2px);
+}
+#sidebar button.active {
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.75), rgba(102, 64, 255, 0.8));
+    border-color: rgba(167, 109, 255, 0.85);
+    color: #fefbff;
+    box-shadow: 0 14px 32px rgba(118, 72, 255, 0.45);
+}
+#sidebar button.active::before {
+    background: #fefbff;
+}
+.sidebar-footer {
+    padding: 1.25rem 1.75rem 1.5rem;
+    border-top: 1px solid var(--sidebar-border);
+    font-size: 0.78rem;
+    color: var(--sidebar-muted);
+    line-height: 1.45;
+}
+#content {
+    flex: 1;
+    padding: 2.75rem 3.5rem;
+    overflow-y: auto;
+    display: flex;
+    justify-content: center;
+}
+.content-inner {
+    width: min(100%, 960px);
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+.hero-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+    padding: 2rem;
+    background: linear-gradient(135deg, rgba(19, 6, 46, 0.92), rgba(44, 15, 98, 0.7));
+    border-radius: 24px;
+    border: 1px solid rgba(167, 109, 255, 0.3);
+    box-shadow: var(--surface-shadow);
+}
+.hero-card h2 {
+    margin: 0 0 0.5rem 0;
+    font-size: 2.1rem;
+}
+.hero-card p {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(167, 109, 255, 0.18);
+    border: 1px solid rgba(167, 109, 255, 0.32);
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+.tag.free-tier {
+    background: rgba(103, 192, 255, 0.18);
+    border-color: rgba(103, 192, 255, 0.42);
+    color: #a5e8ff;
+}
+button {
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    color: #fff;
+    border: none;
+    padding: 0.75rem 1.2rem;
+    border-radius: 14px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+button:hover:not(:disabled),
+button:focus-visible:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 38px rgba(167, 109, 255, 0.35);
+    outline: none;
+}
+button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+    box-shadow: none;
+}
+button.secondary {
+    background: rgba(20, 8, 48, 0.85);
+    border: 1px solid rgba(167, 109, 255, 0.35);
+    color: var(--text-muted);
+}
+button.secondary:hover:not(:disabled),
+button.secondary:focus-visible:not(:disabled) {
+    background: rgba(167, 109, 255, 0.25);
+    color: var(--text);
+    box-shadow: 0 16px 32px rgba(167, 109, 255, 0.25);
+}
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 18px;
+    padding: 1.5rem;
+    backdrop-filter: blur(16px);
+    box-shadow: var(--surface-shadow);
+}
+
+.free-tier-callout {
+    margin: 1rem 0 1.25rem 0;
+    padding: 1rem 1.25rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(103, 192, 255, 0.6);
+    background: rgba(103, 192, 255, 0.12);
+    color: #d6f3ff;
+    line-height: 1.5;
+}
+
+.free-tier-callout strong {
+    color: #ffffff;
+}
+.card h2 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+.cognition-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.cognition-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.cognition-card h3 {
+    margin: 0 0 0.75rem 0;
+    font-size: 1.05rem;
+}
+
+.knowledge-sources {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.knowledge-source {
+    margin: 0;
+}
+
+.knowledge-source-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(167, 109, 255, 0.32);
+    background: rgba(167, 109, 255, 0.12);
+    color: var(--text-muted);
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.knowledge-source-label:hover,
+.knowledge-source-label:focus-within {
+    border-color: rgba(167, 109, 255, 0.55);
+    background: rgba(167, 109, 255, 0.2);
+}
+
+.knowledge-source-label input {
+    accent-color: var(--accent);
+    margin-top: 0.2rem;
+}
+
+.knowledge-source-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.knowledge-source-title {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.knowledge-source-description {
+    font-size: 0.78rem;
+    line-height: 1.45;
+}
+
+.knowledge-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.small-note {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+}
+
+.knowledge-preview {
+    margin-top: 0.35rem;
+    border-radius: 16px;
+    border: 1px solid rgba(167, 109, 255, 0.28);
+    background: rgba(12, 5, 33, 0.85);
+    padding: 1rem 1.25rem;
+    min-height: 160px;
+    max-height: 260px;
+    overflow: auto;
+    white-space: pre-wrap;
+    font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    color: var(--text-muted);
+    box-shadow: inset 0 0 0 1px rgba(167, 109, 255, 0.12);
+}
+.inline-input-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+.inline-input-group input {
+    flex: 1;
+    min-width: 220px;
+}
+.note {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 0.6rem;
+}
+input,
+textarea,
+select {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    margin-top: 0.6rem;
+    border-radius: 14px;
+    border: 1px solid rgba(167, 109, 255, 0.28);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text);
+    font-size: 0.95rem;
+}
+input::placeholder,
+textarea::placeholder {
+    color: rgba(233, 220, 255, 0.5);
+}
+textarea {
+    min-height: 150px;
+    resize: vertical;
+}
+select {
+    appearance: none;
+    background-image: linear-gradient(135deg, rgba(167, 109, 255, 0.25), rgba(167, 109, 255, 0.05));
+}
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1.25rem;
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px rgba(167, 109, 255, 0.22);
+}
+th,
+td {
+    border: 1px solid rgba(167, 109, 255, 0.2);
+    padding: 0.75rem 1rem;
+    text-align: left;
+}
+th {
+    background: rgba(167, 109, 255, 0.18);
+    color: var(--text);
+}
+progress {
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    overflow: hidden;
+    margin-top: 1rem;
+    background: rgba(167, 109, 255, 0.15);
+}
+progress::-webkit-progress-bar {
+    background: transparent;
+}
+progress::-webkit-progress-value {
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.85), rgba(102, 64, 255, 0.85));
+}
+progress::-moz-progress-bar {
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.85), rgba(102, 64, 255, 0.85));
+}
+#chatBox {
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    height: 380px;
+    padding: 1.5rem;
+    overflow-y: auto;
+    background: rgba(7, 2, 24, 0.7);
+    border-radius: 20px;
+    border: 1px solid rgba(167, 109, 255, 0.25);
+}
+.chat-message {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+}
+.chat-message .chat-avatar {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+.chat-message .chat-bubble {
+    padding: 0.85rem 1.05rem;
+    border-radius: 16px;
+    line-height: 1.55;
+    max-width: 100%;
+    box-shadow: inset 0 0 0 1px rgba(167, 109, 255, 0.18);
+    white-space: pre-wrap;
+}
+.chat-message.from-user .chat-avatar {
+    background: linear-gradient(135deg, rgba(167, 109, 255, 0.75), rgba(102, 64, 255, 0.75));
+    color: #fff;
+}
+.chat-message.from-user .chat-bubble {
+    background: rgba(167, 109, 255, 0.18);
+    color: var(--text);
+}
+.chat-message.from-assistant .chat-avatar {
+    background: rgba(255, 255, 255, 0.07);
+    color: var(--text);
+    border: 1px solid rgba(167, 109, 255, 0.28);
+}
+.chat-message.from-assistant .chat-bubble {
+    background: rgba(20, 8, 48, 0.65);
+    color: var(--text-muted);
+}
+#storyOutput {
+    white-space: pre-wrap;
+}
+ul {
+    padding-left: 1.2rem;
+}
+li {
+    margin-bottom: 0.35rem;
+}
+.app-section { display: none; }
+@media (max-width: 1080px) {
+    #layout {
+        flex-direction: column;
+    }
+    #sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--sidebar-border);
+    }
+    #content {
+        padding: 2rem 1.5rem 3rem;
+    }
+}
+.mood-display {
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px;
+    margin-top: 1rem;
+    transition: background-color 0.3s ease;
+}

--- a/tests/free-tier.test.js
+++ b/tests/free-tier.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createFreeTierEngine } from '../scripts/free-tier.js';
+
+describe('createFreeTierEngine', () => {
+  let gatherMock;
+  let recallMock;
+  let knowledgeHub;
+  let memoryVault;
+  const fixedClock = () => new Date('2025-05-01T12:30:00.000Z');
+
+  beforeEach(() => {
+    gatherMock = vi.fn(async () => ({
+      combinedText: 'Свежие данные из сети.',
+      entries: [],
+      errors: []
+    }));
+    recallMock = vi.fn(() => '');
+    knowledgeHub = { gather: gatherMock };
+    memoryVault = { recall: recallMock };
+  });
+
+  it('использует сохранённую агрегацию без дополнительных запросов', async () => {
+    const engine = createFreeTierEngine({ knowledgeHub, memoryVault, clock: fixedClock });
+    engine.recordAggregation({
+      topic: 'квантовые компьютеры',
+      combinedText: 'Ключевые факты о квантовых вычислениях.',
+      errors: []
+    });
+
+    const answer = await engine.respond([
+      { role: 'user', content: 'квантовые компьютеры' }
+    ]);
+
+    expect(gatherMock).not.toHaveBeenCalled();
+    expect(answer.toLowerCase()).toContain('free tier');
+    expect(answer).toContain('квантовые компьютеры');
+    expect(answer).toContain('Интернет-досье');
+  });
+
+  it('обращается к knowledgeHub если кэш пуст и добавляет данные в ответ', async () => {
+    const engine = createFreeTierEngine({ knowledgeHub, memoryVault, clock: fixedClock });
+
+    const answer = await engine.respond([
+      { role: 'user', content: 'Новости ИИ' }
+    ]);
+
+    expect(gatherMock).toHaveBeenCalledWith('Новости ИИ', { limit: 4 });
+    expect(answer).toContain('Новости ИИ');
+    expect(answer).toContain('Интернет-досье');
+  });
+
+  it('встраивает сохранённую память пользователя в ответ бесплатного режима', async () => {
+    recallMock = vi.fn(() => 'Ранее мы планировали запуск продукта Milana.');
+    memoryVault = { recall: recallMock };
+    const engine = createFreeTierEngine({ knowledgeHub, memoryVault, clock: fixedClock });
+    engine.recordAggregation({ topic: 'стратегия', combinedText: '', errors: [] });
+
+    const answer = await engine.respond([
+      { role: 'user', content: 'Обнови стратегию' }
+    ]);
+
+    expect(answer).toContain('Ранее мы планировали запуск продукта Milana.');
+    expect(answer).toContain('План действий');
+  });
+});

--- a/tests/gpt.test.js
+++ b/tests/gpt.test.js
@@ -1,0 +1,198 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { createGptIntegration } from '../scripts/gpt.js';
+
+const createDom = () => {
+  document.body.innerHTML = `
+    <div>
+      <input id="gptApiKey" />
+      <button id="gptSaveKey"></button>
+      <button id="gptTestKey"></button>
+      <button id="gptClearKey"></button>
+      <p id="gptKeyStatus"></p>
+    </div>
+  `;
+
+  return {
+    keyField: document.getElementById('gptApiKey'),
+    saveButton: document.getElementById('gptSaveKey'),
+    testButton: document.getElementById('gptTestKey'),
+    clearButton: document.getElementById('gptClearKey'),
+    statusField: document.getElementById('gptKeyStatus')
+  };
+};
+
+const createStorage = (initial = {}) => {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => store.get(key) || '',
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    snapshot: () => Object.fromEntries(store)
+  };
+};
+
+const createFetchSuccess = (content = 'готово') => {
+  const responses = Array.isArray(content) ? content : [content];
+  let callIndex = 0;
+  return vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      choices: [
+        { message: { content: responses[Math.min(callIndex++, responses.length - 1)] } }
+      ]
+    })
+  }));
+};
+
+const createFetchFailure = (status = 401, message = 'некорректный ключ') => vi.fn(async () => ({
+  ok: false,
+  status,
+  json: async () => ({
+    error: { message }
+  })
+}));
+
+describe('createGptIntegration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-02-14T10:15:00.000Z'));
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('загружает ключ из хранилища и показывает статус готовности', () => {
+    const storage = createStorage({ gptApiKey: 'sk-stored' });
+    const fetchMock = createFetchSuccess();
+    const elements = createDom();
+
+    createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      autoApplyQuery: false
+    });
+
+    expect(elements.keyField.value).toBe('sk-stored');
+    expect(elements.statusField.textContent).toContain('готов к работе');
+  });
+
+  it('выдаёт понятную ошибку если ключ не задан перед запросом', async () => {
+    const storage = createStorage();
+    const fetchMock = createFetchSuccess();
+    const elements = createDom();
+
+    const integration = createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      autoApplyQuery: false
+    });
+
+    await expect(integration.query([
+      { role: 'user', content: 'ping' }
+    ])).rejects.toMatchObject({ code: 'NO_KEY' });
+    expect(elements.statusField.textContent).toContain('Введите ключ');
+  });
+
+  it('успешно проверяет ключ и включает кнопки обратно', async () => {
+    const storage = createStorage();
+    const fetchMock = createFetchSuccess(['готово', 'Отметка времени: 2025-02-14T10:15:00.000Z']);
+    const elements = createDom();
+
+    const integration = createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      autoApplyQuery: false
+    });
+
+    elements.keyField.value = 'sk-check';
+
+    const result = await integration.testKey();
+
+    expect(result).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(elements.statusField.textContent).toContain('Интеграция активна');
+    expect(elements.statusField.textContent).toContain('2025-02-14T10:15:00.000Z');
+    expect(elements.saveButton.disabled).toBe(false);
+    expect(elements.testButton.disabled).toBe(false);
+    expect(storage.snapshot().gptApiKey).toBe('sk-check');
+  });
+
+  it('показывает текст ошибки если проверка завершается неудачно', async () => {
+    const storage = createStorage();
+    const fetchMock = createFetchFailure(401, 'invalid key');
+    const elements = createDom();
+
+    const integration = createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      autoApplyQuery: false
+    });
+
+    elements.keyField.value = 'sk-bad';
+
+    const result = await integration.testKey();
+
+    expect(result).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(elements.statusField.textContent).toContain('Ошибка GPT: invalid key');
+  });
+
+  it('применяет ключ из URL и сразу проводит проверку', async () => {
+    const storage = createStorage();
+    const fetchMock = createFetchSuccess(['готово', 'Подтверждаю время 2025-02-14T10:15:00.000Z']);
+    const elements = createDom();
+
+    const integration = createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      locationHref: 'https://example.com/?sk=sk-url',
+      autoApplyQuery: true
+    });
+
+    await integration.ready;
+
+    expect(storage.snapshot().gptApiKey).toBe('sk-url');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(elements.statusField.textContent).toContain('2025-02-14T10:15:00.000Z');
+  });
+
+  it('использует бесплатный движок если ключ не задан, но разрешён free tier', async () => {
+    const storage = createStorage();
+    const fetchMock = vi.fn(() => {
+      throw new Error('fetch не должен вызываться в бесплатном режиме');
+    });
+    const elements = createDom();
+    const freeTier = {
+      respond: vi.fn(async () => 'ответ free tier')
+    };
+
+    const integration = createGptIntegration({
+      ...elements,
+      storage,
+      fetchImpl: fetchMock,
+      autoApplyQuery: false,
+      freeTier
+    });
+
+    expect(elements.statusField.textContent).toContain('Бесплатный режим');
+
+    const reply = await integration.query([
+      { role: 'user', content: 'привет' }
+    ], { useFreeTier: true });
+
+    expect(reply).toBe('ответ free tier');
+    expect(freeTier.respond).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/knowledge.test.js
+++ b/tests/knowledge.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { createKnowledgeHub } from '../scripts/knowledge.js';
+
+const createStorage = (initial = {}) => {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => store.has(key) ? store.get(key) : null,
+    setItem: (key, value) => { store.set(key, value); },
+    removeItem: (key) => { store.delete(key); },
+    snapshot: () => Object.fromEntries(store)
+  };
+};
+
+describe('createKnowledgeHub', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async (url) => {
+      if (url.includes('wikipedia')) {
+        return {
+          ok: true,
+          json: async () => ({ extract: 'Краткое описание из Википедии.' })
+        };
+      }
+      if (url.includes('hn.algolia.com')) {
+        return {
+          ok: true,
+          json: async () => ({
+            hits: [
+              { title: 'Первая новость', url: 'https://example.com/news' },
+              { title: 'Вторая новость', url: 'https://example.com/second' }
+            ]
+          })
+        };
+      }
+      if (url.includes('openlibrary')) {
+        return {
+          ok: true,
+          json: async () => ({
+            docs: [
+              { title: 'Книга по ИИ', author_name: ['AKSI'], first_publish_year: 2024 }
+            ]
+          })
+        };
+      }
+      return {
+        ok: false,
+        json: async () => ({})
+      };
+    });
+  });
+
+  it('возвращает активные источники и позволяет собирать данные', async () => {
+    const storage = createStorage();
+    const hub = createKnowledgeHub({ storage, fetchImpl: fetchMock });
+
+    expect(hub.getConnectors().map((c) => c.enabled)).toEqual([true, true, false]);
+
+    hub.setConnectorEnabled('openlibrary', true);
+    const result = await hub.gather('машинное обучение', { limit: 2 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.entries).toHaveLength(3);
+    expect(result.errors).toHaveLength(0);
+    expect(result.combinedText).toContain('Википедия');
+    expect(result.combinedText).toContain('Hacker News');
+    expect(result.combinedText).toContain('Open Library');
+    expect(storage.snapshot().gptKnowledgeHub).toBeDefined();
+  });
+
+  it('фиксирует ошибки источников и сообщает об этом', async () => {
+    const errorFetch = vi.fn(async (url) => {
+      if (url.includes('wikipedia')) {
+        return { ok: false, json: async () => ({}) };
+      }
+      return {
+        ok: true,
+        json: async () => ({ hits: [], docs: [] })
+      };
+    });
+
+    const hub = createKnowledgeHub({ storage: createStorage(), fetchImpl: errorFetch });
+    const result = await hub.gather('данные');
+
+    expect(result.entries.some((entry) => entry.error)).toBe(true);
+    expect(result.errors[0]).toContain('Википедия');
+    expect(result.combinedText).toBe('');
+  });
+
+  it('возвращает пустой результат если запрос не задан', async () => {
+    const hub = createKnowledgeHub({ storage: createStorage(), fetchImpl: fetchMock });
+    const result = await hub.gather('');
+
+    expect(result.entries).toEqual([]);
+    expect(result.combinedText).toBe('');
+    expect(result.errors).toContain('Не задан запрос для агрегации данных.');
+  });
+});

--- a/tests/memory.test.js
+++ b/tests/memory.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryVault } from '../scripts/memory.js';
+
+const createStorage = () => {
+  const store = new Map();
+  return {
+    getItem: (key) => store.has(key) ? store.get(key) : null,
+    setItem: (key, value) => { store.set(key, value); },
+    removeItem: (key) => { store.delete(key); },
+    snapshot: () => Object.fromEntries(store)
+  };
+};
+
+describe('createMemoryVault', () => {
+  it('сохраняет и возвращает ограниченный набор записей', () => {
+    const storage = createStorage();
+    const vault = createMemoryVault({ storage, maxEntries: 2 });
+
+    vault.remember({ user: 'Первый вопрос', assistant: 'Первый ответ', timestamp: '2025-01-01T10:00:00.000Z' });
+    vault.remember({ user: 'Второй вопрос', assistant: 'Второй ответ', timestamp: '2025-01-02T10:00:00.000Z' });
+    vault.remember({ user: 'Третий вопрос', assistant: 'Третий ответ', timestamp: '2025-01-03T10:00:00.000Z' });
+
+    const all = vault.exportAll();
+    expect(all).toHaveLength(2);
+    expect(all[0].user).toContain('Второй вопрос');
+    expect(all[1].assistant).toContain('Третий ответ');
+
+    const summary = vault.recall({ limit: 2 });
+    expect(summary).toContain('Второй вопрос');
+    expect(summary).toContain('Третий вопрос');
+  });
+
+  it('очищает память и игнорирует пустые записи', () => {
+    const storage = createStorage();
+    const vault = createMemoryVault({ storage });
+
+    vault.remember({ user: '', assistant: '' });
+    expect(vault.exportAll()).toEqual([]);
+
+    vault.remember({ user: 'Привет', assistant: 'Ответ' });
+    expect(vault.exportAll()).toHaveLength(1);
+
+    vault.clear();
+    expect(vault.exportAll()).toEqual([]);
+    expect(storage.snapshot()).toEqual({});
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    clearMocks: true
+  }
+});


### PR DESCRIPTION
## Summary
- implement a reusable free-tier Super GPT engine that composes answers from the knowledge hub and memory vault when no API key is present
- wire the portal to use the free-tier engine, highlight the free mode in the UI, and style a new callout for the GPT integration card
- cover the fallback behaviour with dedicated Vitest suites for the integration module and the free-tier responder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eeec4365608322bf000fa95ad6e5b5